### PR TITLE
Remote connection support in server

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps  {org.clojure/clojure            {:mvn/version "1.11.1"}
          org.clojure/core.async         {:mvn/version "1.6.673"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :sha     "eae6f973ee1a3b50378292d3b468f8c70683c291"}
+                                         :sha     "3b1013403f4745d7c2596cd6b61a4a0f54f94146"}
          club.donutpower/system         {:mvn/version "0.0.165"}
 
          ;; network, consensus

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps  {org.clojure/clojure            {:mvn/version "1.11.1"}
          org.clojure/core.async         {:mvn/version "1.6.673"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :sha     "3b1013403f4745d7c2596cd6b61a4a0f54f94146"}
+                                         :sha     "2746c2e15d19e2c664d4951aca8131f5e70d3ea4"}
          club.donutpower/system         {:mvn/version "0.0.165"}
 
          ;; network, consensus

--- a/dev/src/query_server.clj
+++ b/dev/src/query_server.clj
@@ -1,0 +1,1 @@
+(ns query-server)

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -41,6 +41,13 @@
                       (assoc-in [:fluree/consensus :consensus-servers] servers-str)
                       (assoc-in [:fluree/consensus :consensus-this-server] server-3)))
 
+
+(def query-server-1-env (-> (server/env-config :dev)
+                            (assoc-in [:http/server :port] 58095)
+                            (assoc-in [:fluree/connection :servers] "http://localhost:58090")
+                            (assoc-in [:fluree/connection :method] :remote)
+                            (assoc-in [:fluree/consensus :consensus-type] :none)))
+
 (defmethod ds/named-system ::srv1
   [_]
   (ds/system :dev {[:env] server-1-env}))
@@ -52,6 +59,11 @@
 (defmethod ds/named-system ::srv3
   [_]
   (ds/system :dev {[:env] server-3-env}))
+
+
+(defmethod ds/named-system ::query1
+  [_]
+  (ds/system :dev {[:env] query-server-1-env}))
 
 
 (defn donut-system
@@ -105,6 +117,8 @@
   ;; read a raft log file
   (fluree.raft.log/read-log-file (io/file "data/srv1/raftlog/0.raft"))
   ;;
+
+  (start-server ::query1)
 
 
   ;; starting a 3 server cluster

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -6,31 +6,33 @@
                                           #profile {:dev    45000
                                                     :prod   45000
                                                     :docker 45000}]}
- :fluree/connection {:method       #or [#env FLUREE_STORAGE_METHOD
-                                        #profile {:dev    :file
-                                                  :prod   :file
-                                                  :docker :file}]
-                     :parallelism  #or [#env FLUREE_CONN_PARALLELISM
-                                        #profile {:dev    1
-                                                  :prod   4
-                                                  :docker 4}]
-                     :storage-path #or [#env FLUREE_STORAGE_PATH
-                                        #profile {:dev    "data"
-                                                  :prod   "data"
-                                                  :docker "data"}]
-                     :cache-max-mb #or [#env FLUREE_CACHE_MAX_MB ;; integer, in MB
-                                        #profile {:dev    100
-                                                  :prod   1000
-                                                  :docker 1000}]
-                     :defaults     {:context-type :string
-                                    :context      {:id   "@id"
-                                                   :type "@type"
-                                                   :ex   "http://example.com/"}}}
- :fluree/consensus  {:servers               #or [#env FLUREE_SERVERS
-                                                 #profile {:dev    nil
-                                                           :prod   nil
-                                                           :docker nil}]
-                     :consensus-servers     #or [#env FLUREE_CONSENSUS_SERVERS
+ :fluree/connection {:remote-servers #or [#env FLUREE_REMOTE_SERVERS
+                                          #profile {:dev    "http://127.0.0.1:58090"
+                                                    :prod   nil
+                                                    :docker nil}]
+                     :method         #or [#env FLUREE_STORAGE_METHOD
+                                          #profile {:dev    :file
+                                                    :prod   :file
+                                                    :docker :file}]
+                     :parallelism    #or [#env FLUREE_CONN_PARALLELISM
+                                          #profile {:dev    1
+                                                    :prod   4
+                                                    :docker 4}]
+                     :storage-path   #or [#env FLUREE_STORAGE_PATH
+                                          #profile {:dev    "data"
+                                                    :prod   "data"
+                                                    :docker "data"}]
+                     :cache-max-mb   #or [#env FLUREE_CACHE_MAX_MB ;; integer, in MB
+                                          #profile {:dev    100
+                                                    :prod   1000
+                                                    :docker 1000}]
+                     :defaults       {:context-type :string
+                                      :indexer      {:reindex-min-bytes 1000
+                                                     :reindex-max-bytes 10000000}
+                                      :context      {:id   "@id"
+                                                     :type "@type"
+                                                     :ex   "http://example.com/"}}}
+ :fluree/consensus  {:consensus-servers     #or [#env FLUREE_CONSENSUS_SERVERS
                                                  #profile {:dev    "/ip4/127.0.0.1/tcp/62071"
                                                            :prod   nil
                                                            :docker nil}]
@@ -38,6 +40,10 @@
                                                  #profile {:dev    "/ip4/127.0.0.1/tcp/62071"
                                                            :prod   nil
                                                            :docker nil}]
+                     :consensus-type        #or [#env FLUREE_CONSENSUS_TYPE
+                                                 #profile {:dev    :raft
+                                                           :prod   :raft
+                                                           :docker :raft}]
                      ;; TODO - trace down both uses of private-key vs private-keys reconcile
                      :private-key           nil
                      :private-keys          nil

--- a/src/fluree/server/components/http.clj
+++ b/src/fluree/server/components/http.clj
@@ -9,6 +9,7 @@
     [fluree.db.util.log :as log]
     [fluree.server.handlers.ledger :as ledger]
     [fluree.server.handlers.create :as create]
+    [fluree.server.handlers.remote-resource :as remote]
     [fluree.server.handlers.transact :as srv-tx]
     [malli.core :as m]
     [muuntaja.core :as muuntaja]
@@ -113,6 +114,12 @@
              [:map
               [:ledger LedgerAlias]
               [:t {:optional true} TValue]]]))
+
+(def DefaultResourceRequestBody
+  (m/schema [:and
+             [:map-of :keyword :any]
+             [:map
+              [:resource LedgerAlias]]]))
 
 (def DefaultContextResponseBody Context)
 
@@ -317,7 +324,11 @@
                   :responses  {200 {:body DefaultContextResponseBody}
                                400 {:body ErrorResponse}
                                500 {:body ErrorResponse}}
-                  :handler    #'ledger/default-context}}]]]
+                  :handler    #'ledger/default-context}}]
+          ["/remoteResource"
+           {:post {:summary "Remote connection resource read"
+                   :parameters {:body DefaultResourceRequestBody}
+                   :handler #'remote/read-handler}}]]]
         {:data {:coercion   (reitit.coercion.malli/create
                               {:strip-extra-keys false})
                 :muuntaja   (muuntaja/create

--- a/src/fluree/server/handlers/remote_resource.clj
+++ b/src/fluree/server/handlers/remote_resource.clj
@@ -1,0 +1,36 @@
+(ns fluree.server.handlers.remote-resource
+  (:require [clojure.string :as str]
+            [fluree.db.conn.proto :as conn-proto]
+            [fluree.db.json-ld.api :as fluree]
+            [fluree.db.util.async :refer [<? <?? go-try]]
+            [fluree.db.util.log :as log]
+            [fluree.server.handlers.ledger :refer [error-catching-handler deref!]]))
+
+
+(defn read-latest-commit
+  [conn resource-name]
+  (go-try
+    (let [commit-addr (<? (conn-proto/-lookup conn resource-name))
+          _           (when-not commit-addr
+                        (throw (ex-info (str "Unable to load. No commit exists for: " alias)
+                                        {:status 400 :error :db/invalid-commit-address})))
+          commit-data (<? (conn-proto/-c-read conn commit-addr))]
+      (assoc commit-data "address" commit-addr))))
+
+(defn resource-address
+  [conn resource-name]
+  (if (str/starts-with? resource-name "fluree:")
+    resource-name
+    (str "fluree:" (name (conn-proto/-method conn)) "://" resource-name)))
+
+(def read-handler
+  (error-catching-handler
+    (fn [{:keys [fluree/conn credential/did] {{resource-name :resource :as params} :body} :parameters :as parameters}]
+      (log/debug "Remote resource read request params:" params)
+      (let [resource-address (resource-address conn resource-name)
+            file-read?       (str/ends-with? resource-address ".json")
+            result           (if file-read?
+                               (<?? (conn-proto/-c-read conn resource-address))
+                               (<?? (read-latest-commit conn resource-address)))]
+        {:status 200
+         :body   result}))))

--- a/test/fluree/server/integration/test_system.clj
+++ b/test/fluree/server/integration/test_system.clj
@@ -63,7 +63,8 @@
                                 "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
                                 "f"      "https://ns.flur.ee/ledger#"}}}
                              :fluree/consensus
-                             {:consensus-servers     multi-addr-1
+                             {:consensus-type        :raft
+                              :consensus-servers     multi-addr-1
                               :consensus-this-server multi-addr-1}}})))
 
 (defn run-test-server


### PR DESCRIPTION
This is the fluree/server portion of https://github.com/fluree/db/pull/558 that supports remote connection types in the library and serves responses required.