### PR TITLE
Fix Docker Build/Run Issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,12 @@ FROM eclipse-temurin:17-jre-jammy AS runner
 RUN mkdir -p /opt/fluree-server
 WORKDIR /opt/fluree-server
 
-COPY --from=builder /usr/src/fluree-server/target/http-server-*.jar ./fluree-server.jar
+COPY --from=builder /usr/src/fluree-server/target/server-*.jar ./server.jar
 
 EXPOSE 8090
 EXPOSE 58090
 
 VOLUME ./data
 
-ENTRYPOINT ["java", "-jar", "fluree-server.jar"]
+ENTRYPOINT ["java", "-jar", "server.jar"]
 CMD ["docker"]

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ target/server-%.jar: $(SOURCES) $(RESOURCES)
 uberjar: target/server-%.jar
 
 docker-build:
-	docker buildx build --platform linux/amd64,linux/arm64 -t fluree/server:latest -t fluree/server:$(shell git rev-parse HEAD) --build-arg="PROFILE=prod" .
+	docker buildx build -t fluree/server:latest -t fluree/server:$(shell git rev-parse HEAD) --build-arg="PROFILE=prod" --load .
 
 docker-run:
 	docker run -p 58090:8090 -v `pwd`/data:/opt/fluree-server/data fluree/server

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -31,15 +31,16 @@
                                                      :reindex-max-bytes 10000000}
                                       :context      {:id   "@id"
                                                      :type "@type"
-                                                     :ex   "http://example.com/"}}}
+                                                     :ex   "http://example.com/"
+                                                     :f    "https://ns.flur.ee/ledger#"}}}
  :fluree/consensus  {:consensus-servers     #or [#env FLUREE_CONSENSUS_SERVERS
                                                  #profile {:dev    "/ip4/127.0.0.1/tcp/62071"
                                                            :prod   nil
-                                                           :docker nil}]
+                                                           :docker "/ip4/127.0.0.1/tcp/62071"}]
                      :consensus-this-server #or [#env FLUREE_CONSENSUS_THIS_SERVER
                                                  #profile {:dev    "/ip4/127.0.0.1/tcp/62071"
                                                            :prod   nil
-                                                           :docker nil}]
+                                                           :docker "/ip4/127.0.0.1/tcp/62071"}]
                      :consensus-type        #or [#env FLUREE_CONSENSUS_TYPE
                                                  #profile {:dev    :raft
                                                            :prod   :raft


### PR DESCRIPTION
A few changes here

- Dockerfile used wrong artifact names so that the `ENTRYPOINT` failed on `docker run`
- `config.edn` needed a `:docker` profile value for `consensus-this-server`
- (it looks like my Makefile suggestions for `docker-build`, `docker-run`, and `docker-push` made their way in here somehow!) `docker-build` needed a `--load` flag to make it into a local machine's image repository