### PR TITLE
fix default conn default context

### DIFF
--- a/resources/config.edn
+++ b/resources/config.edn
@@ -33,11 +33,10 @@
                                       #or [#env FLUREE_DEFAULT_CONTEXT
                                            #include-json-or-edn #env FLUREE_DEFAULT_CONTEXT_FILE
                                            #profile {:dev
-                                                     ["https://ns.flur.ee"
-                                                      {:id   "@id"
-                                                       :type "@type"
-                                                       :ex   "http://example.com/"
-                                                       :f    "https://ns.flur.ee/ledger#"}]}]}}
+                                                     {:id   "@id"
+                                                      :type "@type"
+                                                      :ex   "http://example.com/"
+                                                      :f    "https://ns.flur.ee/ledger#"}}]}}
  :fluree/consensus  {:consensus-servers     #or [#env FLUREE_CONSENSUS_SERVERS
                                                  #profile {:dev    "/ip4/127.0.0.1/tcp/62071"
                                                            :prod   nil


### PR DESCRIPTION
Downstream code expects the conn default context to be a map, not a vector. This backs out the change.