### PR TITLE
use query error formatting fn in query error coercion

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -29,7 +29,8 @@
          info.sunng/ring-jetty9-adapter ^{:antq/exclude "0.30.x"} {:mvn/version  "0.22.2"}
          metosin/reitit                 {:mvn/version "0.6.0"}
          metosin/muuntaja               {:mvn/version "0.6.8"}
-         metosin/malli                  {:mvn/version "0.13.0"}
+         metosin/malli                  {:git/url "https://github.com/metosin/malli.git"
+                                         :git/sha "5211aca498ff7b022c36de4ca713990f5e731a9c" }
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
 
          ;; retries

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps  {org.clojure/clojure            {:mvn/version "1.11.1"}
          org.clojure/core.async         {:mvn/version "1.6.681"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "a9cbf41c355ac7415239fa37e6eb3790faad15b0"}
+                                         :git/sha "51de2707a76fd5237ea5c6ac04ca46861cbaa73d"}
          com.fluree/json-ld             {:git/url "https://github.com/fluree/json-ld.git"
                                          :git/sha "2b4a4cf75f2b823eea7fa221c6b9cbeb68299e90"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps  {org.clojure/clojure            {:mvn/version "1.11.1"}
          org.clojure/core.async         {:mvn/version "1.6.681"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "b3392d5fa9e1e0fff3da435f29f20b168bbfcaf7"}
+                                         :git/sha "310e71e0175302660f8312f1410173e2b63c66a3"}
          com.fluree/json-ld             {:git/url "https://github.com/fluree/json-ld.git"
                                          :git/sha "2b4a4cf75f2b823eea7fa221c6b9cbeb68299e90"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps  {org.clojure/clojure            {:mvn/version "1.11.1"}
          org.clojure/core.async         {:mvn/version "1.6.681"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "51de2707a76fd5237ea5c6ac04ca46861cbaa73d"}
+                                         :git/sha "b3392d5fa9e1e0fff3da435f29f20b168bbfcaf7"}
          com.fluree/json-ld             {:git/url "https://github.com/fluree/json-ld.git"
                                          :git/sha "2b4a4cf75f2b823eea7fa221c6b9cbeb68299e90"}
 

--- a/src/fluree/server/components/http.clj
+++ b/src/fluree/server/components/http.clj
@@ -76,7 +76,7 @@
 
 (def FqlQuery (m/schema [:and
                          [:map-of :keyword :any]
-                         (fql/query-schema [[:from LedgerAlias]])]
+                         (fql/query-schema [])]
                         {:registry fql/registry}))
 
 (def SparqlQuery (m/schema :string))

--- a/src/fluree/server/handlers/ledger.clj
+++ b/src/fluree/server/handlers/ledger.clj
@@ -16,7 +16,7 @@
                          did (assoc :did did)))
         query* (if opts (assoc query :opts opts) query)]
     {:status 200
-     :body   (deref! (fluree/from-query conn query* {:format format}))}))
+     :body   (deref! (fluree/query-connection conn query* {:format format}))}))
 
 (defhandler history
   [{:keys [fluree/conn credential/did]


### PR DESCRIPTION
Related to https://github.com/fluree/db/issues/312

Uses error-formatting fn introduced in https://github.com/fluree/db/pull/598 to format validation errors for query endpoints