### PR TITLE
Feature/subscription

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps  {org.clojure/clojure            {:mvn/version "1.11.1"}
          org.clojure/core.async         {:mvn/version "1.6.681"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "f798df15c9a1c97ab8e392abf7f37fb30f93078a"}
+                                         :git/sha "c82480c938226c42532fe32b0e34a607a9ad80a5"}
          club.donutpower/system         {:mvn/version "0.0.165"}
 
          ;; network, consensus
@@ -26,7 +26,8 @@
          info.sunng/ring-jetty9-adapter ^{:antq/exclude "0.30.x"} {:mvn/version  "0.22.2"}
          metosin/reitit                 {:mvn/version "0.6.0"}
          metosin/muuntaja               {:mvn/version "0.6.8"}
-         metosin/malli                  {:mvn/version "0.13.0"}
+         metosin/malli                  {:git/url "https://github.com/metosin/malli.git"
+                                         :git/sha "5211aca498ff7b022c36de4ca713990f5e731a9c" }
          ring-cors/ring-cors            {:mvn/version "0.1.13"}
 
          ;; retries

--- a/dev/src/http_calls.clj
+++ b/dev/src/http_calls.clj
@@ -27,10 +27,10 @@
   (-> (client/post (str server-1-address "fluree/create")
                    {:body               (json/stringify-UTF8
                                           {
-                                           ;"action" "new"
-                                           "ledger" ledger-name
-                                           "txn"    {"id"      "ex:test1"
-                                                     "ex:name" "Brian"}})
+                                           "@context" {"f" "https://ns.flur.ee/ledger#"}
+                                           "f:ledger" ledger-name
+                                           "@graph"   {"id"      "ex:test1"
+                                                       "ex:name" "Brian"}})
                     ;:headers {"X-Api-Version" "2"}
                     :content-type       :json
                     :socket-timeout     1000 ;; in milliseconds
@@ -39,16 +39,17 @@
 
   (-> (client/post (str server-1-address "fluree/transact")
                    {:body               (json/stringify-UTF8
-                                          {"ledger" ledger-name
-                                           "txn"    {"id"      "ex:test2"
-                                                     "ex:name" "Brian2"}})
+                                          {"@context" {"f" "https://ns.flur.ee/ledger#"}
+                                           "f:ledger" ledger-name
+                                           "@graph"   {"id"      "ex:test2"
+                                                       "ex:name" "Brian2"}})
                     ;:headers {"X-Api-Version" "2"}
                     :content-type       :json
                     :socket-timeout     1000 ;; in milliseconds
                     :connection-timeout 1000 ;; in milliseconds
                     :accept             :json}))
 
-  (-> (client/post (str server-3-address "fluree/query")
+  (-> (client/post (str server-1-address "fluree/query")
                    {:body               (json/stringify-UTF8
                                           {"select" {"?s" ["*"]}
                                            "from"   ledger-name

--- a/src/fluree/server/components/consensus.clj
+++ b/src/fluree/server/components/consensus.clj
@@ -7,23 +7,25 @@
 (set! *warn-on-reflection* true)
 
 (defn start-raft
-  [config connection watcher conn-storage-path]
+  [config connection watcher subscriptions conn-storage-path]
   (log/debug "Starting raft consensus with config:" config)
   (let [handler (consensus-handler/create-handler consensus-handler/default-routes)]
     (consensus/start handler (assoc config :join? false
                                            :ledger-directory conn-storage-path
                                            :fluree/conn connection
-                                           :fluree/watcher watcher))))
+                                           :fluree/watcher watcher
+                                           :fluree/subscriptions subscriptions))))
 
 (def consensus
-  #::ds{:start  (fn [{{:keys [config fluree/connection fluree/watcher conn-storage-path]} ::ds/config}]
+  #::ds{:start  (fn [{{:keys [config fluree/connection fluree/watcher fluree/subscriptions conn-storage-path]} ::ds/config}]
                   (let [{:keys [consensus-type]} config]
                     (case consensus-type
-                      :raft (start-raft config connection watcher conn-storage-path)
+                      :raft (start-raft config connection watcher subscriptions conn-storage-path)
                       :none (log/info "No consensus, starting as query server."))))
         :stop   (fn [{::ds/keys [instance]}]
                   (when instance ((:close instance))))
-        :config {:config            (ds/ref [:env :fluree/consensus])
-                 :conn-storage-path (ds/ref [:env :fluree/connection :storage-path])
-                 :fluree/watcher    (ds/local-ref [:watcher])
-                 :fluree/connection (ds/local-ref [:conn])}})
+        :config {:config               (ds/ref [:env :fluree/consensus])
+                 :conn-storage-path    (ds/ref [:env :fluree/connection :storage-path])
+                 :fluree/watcher       (ds/local-ref [:watcher])
+                 :fluree/connection    (ds/local-ref [:conn])
+                 :fluree/subscriptions (ds/ref [:fluree :subscriptions])}})

--- a/src/fluree/server/components/subscriptions.clj
+++ b/src/fluree/server/components/subscriptions.clj
@@ -1,0 +1,219 @@
+(ns fluree.server.components.subscriptions
+  (:require [clojure.core.async :as async]
+            [donut.system :as ds]
+            [fluree.db.util.core :as util]
+            [fluree.db.util.json :as json]
+            [fluree.db.util.log :as log]
+            [ring.adapter.jetty9.websocket :as ws])
+  (:import (java.io IOException)
+           (java.nio.channels ClosedChannelException)))
+
+
+;; structure of subscriptions atom:
+;{:subs    {"id" {:chan   port ;; <- core.async channel
+;                 :ledgers {"some/ledger" {}} ;; <- map where each key is a ledger-id subscribed to
+;                 :did     nil}}
+; :closed? false}
+
+(def default-subscription-atom (atom {:subs    {}
+                                      :closed? false}))
+
+(defn close-chan
+  [chan message]
+  ;; events are of structure [ledger-id event-name event-data]
+  (when message
+    (async/put! chan [nil :closing message]))
+  (async/close! chan))
+
+(defn all-chans
+  [sub-state]
+  (->> sub-state
+       :subs
+       vals
+       (map :chan)))
+
+(defn all-sub-ids
+  [sub-state]
+  (->> sub-state
+       :subs
+       keys))
+
+(defn all-sockets
+  [sub-state]
+  (->> sub-state
+       :subs
+       vals
+       (map :ws)))
+
+(defn close-all-chans
+  "When shutting down, sends a closing event to all channels immediately
+  before closing connection."
+  [sub-state]
+  (->> (all-chans sub-state)
+       (run! (fn [chan]
+               (close-chan chan "Shutting down"))))
+  sub-state)
+
+;; TODO - send proper closing code
+(defn close-all-sockets
+  [sub-state]
+  (->> (all-sockets sub-state)
+       (run! (fn [ws]
+               (ws/close! ws))))
+  sub-state)
+
+(defn mark-closed
+  "Mark all subscriptions as closing to prevent any new ones from registering
+  while shutting down."
+  [sub-atom]
+  (swap! sub-atom assoc :closed? true))
+
+(defn establish-subscription
+  "Establish a new communication subscription with a client using async chan
+  to send messages"
+  [{:keys [sub-atom] :as subscriptions} websocket sub-id sub-chan opts]
+  (log/warn "establish-subscription - subscriptions: " subscriptions)
+  (log/debug "Establishing new subscription id:" sub-id "with opts" opts)
+  (swap! sub-atom update-in [:subs sub-id]
+         (fn [{:keys [chan ws] :as existing-sub}]
+           (when chan
+             (close-chan chan "Duplicate subscription"))
+           (when ws
+             (ws/close! ws))
+           (assoc existing-sub :chan sub-chan :ws websocket))))
+
+(defn close-subscription
+  [{:keys [sub-atom] :as subscriptions} sub-id status-code reason]
+  (log/debug "Closing websocket subscription for sub-id:" sub-id
+             "with status code:" status-code "and reason:" reason)
+  (let [{:keys [chan ws]} (get-in @sub-atom [:subs sub-id])]
+    (close-chan chan nil)
+    (try (ws/close! ws)
+         (catch Exception _ :ignore))
+    (swap! subscriptions update :subs dissoc sub-id)))
+
+(defn subscribe-ledger
+  "Subscribe to ledger"
+  [{:keys [sub-atom] :as subscriptions} sub-id {:keys [ledger serialization] :as request}]
+  (log/debug "Subscribe websocket request by sub-id" sub-id "request:" request)
+  (swap! sub-atom update-in [:subs sub-id]
+         (fn [existing-sub]
+           (if existing-sub
+             (assoc-in existing-sub [:ledgers ledger] {:serialization serialization})
+             (log/info "Existing subscription for sub-id: " sub-id "cannot be found, assume just closed.")))))
+
+(defn unsubscribe-ledger
+  "Unsubscribe from ledger"
+  [{:keys [sub-atom] :as subscriptions} sub-id {:keys [ledger] :as request}]
+  (log/debug "Unsubscribe websocket request by sub-id" sub-id "request:" request)
+  (swap! sub-atom update-in [:subs sub-id :ledgers]
+         (fn [ledger-subs]
+           (if ledger-subs
+             (dissoc ledger-subs ledger)
+             (log/info "Existing subscription for sub-id: " sub-id "cannot be found, assume just closed.")))))
+
+(defn send-message
+  "Sends a message to an individual socket. If an exception occurs,
+  closes the socket and removes it from the subscription map."
+  [{:keys [sub-atom] :as subscriptions} sub-id message]
+  (let [ws (get-in @sub-atom [:subs sub-id :ws])]
+    (try
+      (ws/send! ws message)
+      (catch IOException _
+        (log/info "Websocket channel closed (java.io.IOException) for sub-id: " sub-id))
+      (catch ClosedChannelException _
+        (log/info "Websocket channel closed for sub-id: " sub-id)
+        (close-subscription subscriptions sub-id nil nil))
+      (catch Exception e
+        (log/error e "Error sending message to websocket subscriber: " sub-id)
+        (close-subscription subscriptions sub-id nil nil)))))
+
+
+(defn send-ledger-message
+  "Sends a message only to subscriptions that subscribed to a ledger.
+  Note the message format should be a JSON-stringified map in the form of:
+  {action: commit, ledger: myledger, data: {...}}"
+  [{:keys [sub-atom] :as subscriptions} ledger-id message]
+  (log/debug "Sending ledger message for:" ledger-id "with message:" message)
+  (let [{:keys [closed? subs]} @sub-atom]
+    (when-not closed?
+      (doseq [[sub-id {:keys [ws ledgers]}] subs]
+        (when (contains? ledgers ledger-id)
+          ;; TODO - use ledger subscription opts to filter out messages, permission
+          (send-message subscriptions sub-id message))))))
+
+
+(defn send-message-to-all
+  "Sends a message to all subscriptions. Message sent as JSON stringified map
+  in the form: {action: commit, ledger: my/ledger, data: {...}}"
+  [{:keys [sub-atom] :as subscriptions} action ledger-alias data]
+  (log/warn "SEND MESSAGE TO ALL subscriptions: " subscriptions)
+  (let [data*   (if (string? data)
+                  (json/parse data false)
+                  data)
+        message (json/stringify {"action" action
+                                 "ledger" ledger-alias
+                                 "data"   data*})
+        sub-ids (all-sub-ids @sub-atom)]
+    (run! #(send-message subscriptions % message) sub-ids)))
+
+
+(defn close
+  [{:keys [sub-atom] :as _subscriptions}]
+  (log/info "Closing all websocket subscriptions.")
+  (-> sub-atom
+      mark-closed
+      close-all-chans
+      close-all-sockets)
+  (reset! sub-atom {:closed? true}))
+
+(def subscriptions
+  #::ds{:start  (fn [{{:keys [subscription-atom]
+                       :or   {subscription-atom default-subscription-atom}} ::ds/config}]
+                  {:sub-atom subscription-atom})
+        :stop   (fn [{::ds/keys [instance]}]
+                  (close instance))
+        :config {}})
+
+
+(defmulti client-message :msg-type)
+
+(defmethod client-message :on-connect
+  [{:keys [fluree/subscriptions http/sub-id http/sub-chan http/ws]}]
+  (establish-subscription subscriptions ws sub-id sub-chan nil))
+
+(defmethod client-message :on-text
+  [{:keys [fluree/subscriptions http/sub-id payload]}]
+  (try
+    (let [request (json/parse payload true)
+          {:keys [action]} request]
+      (case action
+        "subscribe"
+        (subscribe-ledger subscriptions sub-id request)
+
+        "unsubscribe"
+        (unsubscribe-ledger subscriptions sub-id request)
+
+        "ping" ;; Note in-browser websocket doesn't support ping/pong, so this is a no-op to keep alive
+        (do
+          (log/trace "Websocket keep-alive from sub-id:" sub-id)
+          nil)))
+    (catch Exception e
+      (log/error e "Error with :on-text message from websocket subscriber: " sub-id))))
+
+(defmethod client-message :on-bytes
+  [{:keys [http/sub-id payload offset len]}]
+  (log/info "websocket :on-bytes (no-op) message for sub-id: " sub-id))
+
+;; pong handled automatically, no response needed
+(defmethod client-message :on-ping
+  [{:keys [http/sub-id payload]}]
+  (log/trace "ws :on-ping message received from: " sub-id "with payload: " payload))
+
+(defmethod client-message :on-error
+  [{:keys [http/sub-id error]}]
+  (log/warn "Websocket error for sub-id: " sub-id "with error: " (type error)))
+
+(defmethod client-message :on-close
+  [{:keys [fluree/subscriptions http/sub-id status-code reason]}]
+  (close-subscription subscriptions sub-id status-code reason))

--- a/src/fluree/server/consensus/core.clj
+++ b/src/fluree/server/consensus/core.clj
@@ -99,11 +99,12 @@
 
 (defn add-state-machine
   "Add state machine configuration options needed for raft"
-  [{:keys [fluree/conn fluree/watcher this-server command-chan storage-ledger-read storage-ledger-write] :as raft-config}
+  [{:keys [fluree/conn fluree/watcher fluree/subscriptions this-server command-chan storage-ledger-read storage-ledger-write] :as raft-config}
    handler]
   (let [state-machine-atom   (atom raft-helpers/default-state)
         state-machine-config {:fluree/conn                    conn
                               :fluree/watcher                 watcher
+                              :fluree/subscriptions           subscriptions
                               :consensus/command-chan         command-chan
                               :consensus/this-server          this-server
                               :consensus/state-atom           state-machine-atom

--- a/src/fluree/server/handlers/ledger.clj
+++ b/src/fluree/server/handlers/ledger.clj
@@ -16,7 +16,7 @@
                          did (assoc :did did)))
         query* (if opts (assoc query :opts opts) query)]
     {:status 200
-     :body   (deref! (fluree/from-query conn query* {:format format}))}))
+     :body   (deref! (fluree/query-connection conn query* {:format format}))}))
 
 (defhandler history
   [{:keys [fluree/conn credential/did]

--- a/src/fluree/server/main.clj
+++ b/src/fluree/server/main.clj
@@ -6,6 +6,7 @@
             [fluree.server.components.consensus :as consensus]
             [fluree.server.components.http :as http]
             [fluree.server.components.watcher :as watcher]
+            [fluree.server.components.subscriptions :as subscriptions]
             [fluree.server.components.fluree :as fluree])
   (:gen-class))
 
@@ -21,23 +22,26 @@
    {:env    {:http/server       {}
              :fluree/connection {}
              :fluree/consensus  {}}
-    :fluree {:conn      fluree/conn
-             :consensus consensus/consensus
-             :watcher   watcher/watcher}
+    :fluree {:conn          fluree/conn
+             :consensus     consensus/consensus
+             :watcher       watcher/watcher
+             :subscriptions subscriptions/subscriptions}
     :http   {:server  http/server
-             :handler #::ds{:start  (fn [{{:keys [fluree/connection fluree/consensus fluree/watcher] :as cfg
+             :handler #::ds{:start  (fn [{{:keys [fluree/connection fluree/consensus fluree/watcher fluree/subscriptions] :as cfg
                                            {:keys [routes middleware]} :http}
                                           ::ds/config}]
                                       (log/debug "ds/config:" cfg)
-                                      (http/app {:fluree/conn      connection
-                                                 :fluree/consensus consensus
-                                                 :fluree/watcher   watcher
-                                                 :http/routes      routes
-                                                 :http/middleware  middleware}))
-                            :config {:http              (ds/ref [:env :http/server])
-                                     :fluree/connection (ds/ref [:fluree :conn])
-                                     :fluree/watcher    (ds/ref [:fluree :watcher])
-                                     :fluree/consensus  (ds/ref [:fluree :consensus])}}}}})
+                                      (http/app {:fluree/conn          connection
+                                                 :fluree/consensus     consensus
+                                                 :fluree/watcher       watcher
+                                                 :fluree/subscriptions subscriptions
+                                                 :http/routes          routes
+                                                 :http/middleware      middleware}))
+                            :config {:http                 (ds/ref [:env :http/server])
+                                     :fluree/connection    (ds/ref [:fluree :conn])
+                                     :fluree/watcher       (ds/ref [:fluree :watcher])
+                                     :fluree/consensus     (ds/ref [:fluree :consensus])
+                                     :fluree/subscriptions (ds/ref [:fluree :subscriptions])}}}}})
 
 (defmethod ds/named-system :base
   [_]


### PR DESCRIPTION
This is companion support for `fluree/db` subscriptions: https://github.com/fluree/db/pull/605

When connecting to a fluree/server, the fluree/db library now launches a socket connection to keep up to date on ledger changes and maintains its internal state and a current copy of db's that are actively being used from the library.
