### PR TITLE
add test for successful jws tests

### DIFF
--- a/test/fluree/server/integration/policy_test.clj
+++ b/test/fluree/server/integration/policy_test.clj
@@ -147,12 +147,25 @@
                   "policy opts prevented seeing bob's secret"))))
         (testing "JWS requests"
           (let [txn-req {"@context" ["https://ns.flur.ee" test-system/default-context]
+                         "ledger" ledger-name
+                         "insert" {"id" "ex:alice"
+                                   "ex:secret" "Alice's new secret"}}
+                txn-res (api-post :transact {:body (json/write-value-as-string
+                                                    (crypto/create-jws
+                                                     (json/write-value-as-string txn-req)
+                                                     (:private auth)))
+                                             :headers json-headers})]
+            (is (= 200
+                   (:status txn-res))
+                "authorized transaction"))
+          (let [txn-req {"@context" ["https://ns.flur.ee" test-system/default-context]
                          "ledger"   ledger-name
                          "insert"   [{"id" "ex:bob"}
                                      "ex:secret" "bob's new secret"]}
-                txn-res (api-post :transact {:body    (crypto/create-jws
-                                                       (json/write-value-as-string txn-req)
-                                                       (:private auth))
+                txn-res (api-post :transact {:body    (json/write-value-as-string
+                                                       (crypto/create-jws
+                                                        (json/write-value-as-string txn-req)
+                                                        (:private auth)))
                                              :headers json-headers})]
             (is (not= 200 (:status txn-res))
                 "transaction policy opts prevented modification")

--- a/test/fluree/server/integration/policy_test.clj
+++ b/test/fluree/server/integration/policy_test.clj
@@ -146,29 +146,32 @@
                      (-> query-res :body json/read-value first (get "f:assert")))
                   "policy opts prevented seeing bob's secret"))))
         (testing "JWS requests"
-          (let [txn-req {"@context" ["https://ns.flur.ee" test-system/default-context]
-                         "ledger" ledger-name
-                         "insert" {"id" "ex:alice"
-                                   "ex:secret" "Alice's new secret"}}
-                txn-res (api-post :transact {:body (json/write-value-as-string
-                                                    (crypto/create-jws
-                                                     (json/write-value-as-string txn-req)
-                                                     (:private auth)))
-                                             :headers json-headers})]
-            (is (= 200
-                   (:status txn-res))
-                "authorized transaction"))
-          (let [txn-req {"@context" ["https://ns.flur.ee" test-system/default-context]
-                         "ledger"   ledger-name
-                         "insert"   [{"id" "ex:bob"}
-                                     "ex:secret" "bob's new secret"]}
-                txn-res (api-post :transact {:body    (json/write-value-as-string
-                                                       (crypto/create-jws
-                                                        (json/write-value-as-string txn-req)
-                                                        (:private auth)))
-                                             :headers json-headers})]
-            (is (not= 200 (:status txn-res))
-                "transaction policy opts prevented modification")
+          (testing "authorized signer"
+            (let [txn-req {"@context" ["https://ns.flur.ee" test-system/default-context]
+                           "ledger" ledger-name
+                           "insert" {"id" "ex:alice"
+                                     "ex:secret" "Alice's new secret"}}
+                  txn-res (api-post :transact {:body (json/write-value-as-string
+                                                      (crypto/create-jws
+                                                       (json/write-value-as-string txn-req)
+                                                       (:private auth)))
+                                               :headers json-headers})]
+              (is (= 200
+                     (:status txn-res))
+                  "txn signed by authorized user succeeds")))
+          (testing "unauthorized signer"
+            (let [txn-req {"@context" ["https://ns.flur.ee" test-system/default-context]
+                           "ledger"   ledger-name
+                           "insert"   [{"id" "ex:bob"}
+                                       "ex:secret" "bob's new secret"]}
+                  txn-res (api-post :transact {:body    (json/write-value-as-string
+                                                         (crypto/create-jws
+                                                          (json/write-value-as-string txn-req)
+                                                          (:private auth)))
+                                               :headers json-headers})]
+              (is (not= 200 (:status txn-res))
+                  "transaction policy opts prevented modification")))
+          (testing "query results filtered based on authorization"
             (let [query-req {"@context" test-system/default-context
                              "from"     ledger-name
                              "history"  "ex:bob"


### PR DESCRIPTION
The request body needs to be json encoded if it's sent with json headers, just a string will cause weird/broken behavior.