### PR TITLE
Feature/sync sid calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@
 /.clj-kondo/*
 !/.clj-kondo/config.edn
 /.lsp/
-/.dir-locals.el

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /.clj-kondo/*
 !/.clj-kondo/config.edn
 /.lsp/
+/.dir-locals.el

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/fluree-server
 
 COPY deps.edn ./
 
-RUN clojure -P && clojure -A:build:test -P
+RUN clojure -P && clojure -X:deps prep && clojure -A:build:test -P
 
 COPY . ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/fluree-server
 
 COPY deps.edn ./
 
-RUN clojure -P && clojure -X:deps prep && clojure -A:build:test -P
+RUN clojure -X:deps prep && clojure -P && clojure -A:build:test -P
 
 COPY . ./
 

--- a/Makefile
+++ b/Makefile
@@ -15,27 +15,31 @@ docker-run:
 docker-push:
 	docker buildx build --platform linux/amd64,linux/arm64 -t fluree/server:latest -t fluree/server:$(shell git rev-parse HEAD) --build-arg="PROFILE=prod" --push .
 
+.PHONY: prepare
+prepare:
+	clojure -X:deps prep
+
 .PHONY: test
-test:
-	clojure -X:deps prep && clojure -X:test
+test: prepare
+	clojure -X:test
 
 .PHONY: pending-tests
-pending-tests:
+pending-tests: prepare
 	clojure -X:pending-tests
 
 .PHONY: pt
 pt: pending-tests
 
 .PHONY: clj-kondo-lint
-clj-kondo-lint:
+clj-kondo-lint: prepare
 	clj-kondo --lint src:test:build.clj
 
 .PHONY: clj-kondo-lint-ci
-clj-kondo-lint-ci:
+clj-kondo-lint-ci: prepare
 	clj-kondo --lint src:test:build.clj --config .clj-kondo/ci-config.edn
 
 .PHONY: cljfmt-check
-cljfmt-check:
+cljfmt-check: prepare
 	cljfmt check src test build.clj
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 SOURCES := $(shell find src)
 RESOURCES := $(shell find resources)
 
-target/server-%.jar: $(SOURCES) $(RESOURCES)
-	clojure -X:deps prep && clojure -T:build uber
+.PHONY: prepare
+prepare:
+	clojure -X:deps prep
+
+target/server-%.jar: $(SOURCES) $(RESOURCES) prepare
+	clojure -T:build uber
 
 uberjar: target/server-%.jar
 
@@ -14,10 +18,6 @@ docker-run:
 
 docker-push:
 	docker buildx build --platform linux/amd64,linux/arm64 -t fluree/server:latest -t fluree/server:$(shell git rev-parse HEAD) --build-arg="PROFILE=prod" --push .
-
-.PHONY: prepare
-prepare:
-	clojure -X:deps prep
 
 .PHONY: test
 test: prepare

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ The most common environment variables to set would include:
 
 ## Development
 
+### Dependencies
+
+Run `make prepare` to compile the required dependencies to enable Clojure development.
+
 ### Git hooks
 
 - Run `bb run git-hooks install`

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps  {org.clojure/clojure            {:mvn/version "1.11.1"}
          org.clojure/core.async         {:mvn/version "1.6.681"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "d2a12ce996f62bb56177d903da14debf19a327a7"
+                                         :git/sha "d2a12ce996f62bb56177d903da14debf19a327a7"}
          com.fluree/json-ld             {:git/url "https://github.com/fluree/json-ld.git"
                                          :git/sha "0958995acf5540271d1807fc6d8f2da131164e24"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps  {org.clojure/clojure            {:mvn/version "1.11.1"}
          org.clojure/core.async         {:mvn/version "1.6.681"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "6275e61ad35044d4d3ec34feec1a2eaf369835f0"}
+                                         :git/sha "3ca8903cdfa5d3f7e4105c894c465e1ab4a41509"}
          com.fluree/json-ld             {:git/url "https://github.com/fluree/json-ld.git"
                                          :git/sha "0958995acf5540271d1807fc6d8f2da131164e24"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps  {org.clojure/clojure            {:mvn/version "1.11.1"}
          org.clojure/core.async         {:mvn/version "1.6.681"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "1fa39b74fa61deb3df1503060569395e86267fd1"}
+                                         :git/sha "de3b4f5d6f38c0a6a75e4b6f5bbc2f74bccca930"}
          com.fluree/json-ld             {:git/url "https://github.com/fluree/json-ld.git"
                                          :git/sha "0958995acf5540271d1807fc6d8f2da131164e24"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps  {org.clojure/clojure            {:mvn/version "1.11.1"}
          org.clojure/core.async         {:mvn/version "1.6.681"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "151611dc39f10d6ef3e92be94c694c674ad48445"}
+                                         :git/sha "d2a12ce996f62bb56177d903da14debf19a327a7"
          com.fluree/json-ld             {:git/url "https://github.com/fluree/json-ld.git"
                                          :git/sha "0958995acf5540271d1807fc6d8f2da131164e24"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps  {org.clojure/clojure            {:mvn/version "1.11.1"}
          org.clojure/core.async         {:mvn/version "1.6.681"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "6360c1b13d0b3f66eae6c6260bb0bb45cb9f0ffc"}
+                                         :git/sha "6275e61ad35044d4d3ec34feec1a2eaf369835f0"}
          com.fluree/json-ld             {:git/url "https://github.com/fluree/json-ld.git"
                                          :git/sha "0958995acf5540271d1807fc6d8f2da131164e24"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps  {org.clojure/clojure            {:mvn/version "1.11.1"}
          org.clojure/core.async         {:mvn/version "1.6.681"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "3ca8903cdfa5d3f7e4105c894c465e1ab4a41509"}
+                                         :git/sha "151611dc39f10d6ef3e92be94c694c674ad48445"}
          com.fluree/json-ld             {:git/url "https://github.com/fluree/json-ld.git"
                                          :git/sha "0958995acf5540271d1807fc6d8f2da131164e24"}
 

--- a/resources/config-migrater.edn
+++ b/resources/config-migrater.edn
@@ -1,0 +1,3 @@
+#:fluree{:migrater       {:ledgers #env FLUREE_MIGRATE_LEDGERS}
+         :commit-options {:did     #env FLUREE_DID
+                          :private #env FLUREE_PRIVATE_KEY}}

--- a/src/fluree/server/components/consensus_handler.clj
+++ b/src/fluree/server/components/consensus_handler.clj
@@ -16,7 +16,6 @@
   {:ledger-create          {:summary         "Request to create a new ledger. Generates :ledger-created event when successful"
                             :parameters      {:ledger    ::http-routes/ledger
                                               :txn       ::http-routes/txn
-                                              :conn-type keyword?
                                               :size      pos-int?
                                               :instant   pos-int?}
                             :auth            {} ;; specific authorization logic to determine if action is allowed.
@@ -26,7 +25,6 @@
    :ledger-created         {:summary    "A new ledger has been created by a ledger node, register."
                             :parameters {:ledger    ::http-routes/ledger
                                          :txn       ::http-routes/txn
-                                         :conn-type keyword?
                                          :size      pos-int?
                                          :instant   pos-int?}
                             :auth       {} ;; specific authorization logic to determine if action is allowed.

--- a/src/fluree/server/components/fluree.clj
+++ b/src/fluree/server/components/fluree.clj
@@ -1,6 +1,6 @@
 (ns fluree.server.components.fluree
   (:require [donut.system :as ds]
-            [fluree.db.conn.proto :as conn-proto]
+            [fluree.db.connection :as connection]
             [fluree.db.json-ld.api :as db]
             [fluree.db.util.log :as log]))
 
@@ -10,5 +10,5 @@
                   @(db/connect options))
         :stop   (fn [{::ds/keys [instance]}]
                   ;; TODO: Add a close-connection fn to f.d.json-ld.api
-                  (when instance (conn-proto/-close instance)))
+                  (when instance (connection/-close instance)))
         :config {:options (ds/ref [:env :fluree/connection])}})

--- a/src/fluree/server/components/migrate.clj
+++ b/src/fluree/server/components/migrate.clj
@@ -1,0 +1,59 @@
+(ns fluree.server.components.migrate
+  (:require [clojure.core.async :as async :refer [>!]]
+            [donut.system :as ds]
+            [fluree.db.util.core :as util]
+            [fluree.db.util.async :refer [<?? <? go-try]]
+            [fluree.db.json-ld.migrate.sid :as sid]
+            [fluree.db.nameservice.core :as nameservice]
+            [fluree.server.consensus.producers.new-index-file :as new-index-file]
+            [fluree.db.util.log :as log]))
+
+(defn push-migrated-index-files
+  "Monitors for new index files pushed onto the changes channel.
+
+  Sends them out one at a time for now, but network interaction optimization
+  would be likely if we batched them up to a specific size."
+  ([config index-files-ch resp-ch]
+   (async/go-loop []
+     (let [next-file-event (async/<! index-files-ch)]
+       ;; if chan is closed, will stop monitoring loop
+       (if next-file-event
+         (do (log/debug "About to push new index file event through consensus: " next-file-event)
+             (if (util/exception? next-file-event)
+               (do (log/error next-file-event "Error in push-new-index-files monitoring new index files, but got an exception.")
+                   (when resp-ch
+                     (>! resp-ch next-file-event)))
+               (let [resp @(new-index-file/push-index-file config next-file-event)]
+                 (when resp-ch
+                   (>! resp-ch resp))
+                 (recur))))
+         (when resp-ch
+           (async/close! resp-ch)))))))
+
+(defn sid-migrate-ledgers
+  [conn consensus-config ledgers]
+  (go-try
+    (let [index-files-ch (async/chan)
+          resp-ch        (async/chan)]
+      (push-migrated-index-files consensus-config index-files-ch resp-ch)
+      (loop [[alias & r] ledgers]
+        (if alias
+          (let [address (<? (nameservice/primary-address conn alias nil))]
+            (log/info "Migrating ledger" alias "at address" address)
+            (<? (sid/migrate conn address index-files-ch))
+            (if-let [_resp (<? resp-ch)]
+              (do (log/info "Ledger" alias "migrated successfully")
+                  (recur r))
+              (log/info "Got no response from consensus group. Stopping migration.")))
+          (do (<? resp-ch)
+              (log/info "All ledgers migrated successfully")))))))
+
+(def sid-migrator
+  #::ds{:env    {:fluree/ledgers []}
+        :config {:fluree/connection       (ds/ref [:fluree :conn])
+                 :fluree/consensus-config (ds/ref [:env :fluree/consensus])}
+        :start  (fn [{{:keys [fluree/connection fluree/consensus-config] :as _cfg}
+                     ::ds/config
+                     {:keys [fluree/ledgers]}
+                     ::ds/env}]
+                  (<?? (sid-migrate-ledgers connection consensus-config ledgers)))})

--- a/src/fluree/server/components/migrate.clj
+++ b/src/fluree/server/components/migrate.clj
@@ -6,8 +6,7 @@
             [fluree.db.util.async :refer [<?? <? go-try]]
             [fluree.db.util.core :as util]
             [fluree.db.util.log :as log]
-            [fluree.server.consensus.producers.new-index-file :as new-index-file]
-            [fluree.server.consensus.raft.core :refer [is-leader?]]))
+            [fluree.server.consensus.producers.new-index-file :as new-index-file]))
 
 ;; TODO: this function is unused, but would be necessary if migrating through
 ;; consensus

--- a/src/fluree/server/components/migrate.clj
+++ b/src/fluree/server/components/migrate.clj
@@ -1,6 +1,7 @@
 (ns fluree.server.components.migrate
-  (:require [clojure.core.async :as async :refer [>!]]
+  (:require [clojure.core.async :as async :refer [<! >! go-loop]]
             [donut.system :as ds]
+            [fluree.server.consensus.raft.core :refer [is-leader?]]
             [fluree.db.util.core :as util]
             [fluree.db.util.async :refer [<?? <? go-try]]
             [fluree.db.json-ld.migrate.sid :as sid]
@@ -8,53 +9,70 @@
             [fluree.server.consensus.producers.new-index-file :as new-index-file]
             [fluree.db.util.log :as log]))
 
+;; TODO: this function is unused, but would be necessary if migrating through
+;; consensus
 (defn push-migrated-index-files
-  "Monitors for new index files pushed onto the changes channel.
+  [consensus index-files-ch resp-ch]
+  (go-loop []
+    (let [next-file-event (<! index-files-ch)]
+      ;; if chan is closed, will stop monitoring loop
+      (if next-file-event
+        (do (log/debug "About to push new index file event through consensus: " next-file-event)
+            (if (util/exception? next-file-event)
+              (do (log/error next-file-event "Error in push-new-index-files monitoring new index files, but got an exception.")
+                  (when resp-ch
+                    (>! resp-ch next-file-event)))
+              (let [resp @(new-index-file/push-index-file consensus next-file-event)]
+                (when resp-ch
+                  (>! resp-ch resp))
+                (recur))))
+        (when resp-ch
+          (async/close! resp-ch))))))
 
-  Sends them out one at a time for now, but network interaction optimization
-  would be likely if we batched them up to a specific size."
-  ([config index-files-ch resp-ch]
-   (async/go-loop []
-     (let [next-file-event (async/<! index-files-ch)]
-       ;; if chan is closed, will stop monitoring loop
-       (if next-file-event
-         (do (log/debug "About to push new index file event through consensus: " next-file-event)
-             (if (util/exception? next-file-event)
-               (do (log/error next-file-event "Error in push-new-index-files monitoring new index files, but got an exception.")
-                   (when resp-ch
-                     (>! resp-ch next-file-event)))
-               (let [resp @(new-index-file/push-index-file config next-file-event)]
-                 (when resp-ch
-                   (>! resp-ch resp))
-                 (recur))))
-         (when resp-ch
-           (async/close! resp-ch)))))))
+(defn log-migrated-index-files
+  "Takes and logs any files from the `index-files-ch`"
+  [index-files-ch error-ch]
+  (go-loop []
+    (when-let [next-file-event (<! index-files-ch)]
+      (if (util/exception? next-file-event)
+        (do (log/error next-file-event "Error storing index file")
+            (when error-ch
+              (>! error-ch next-file-event)))
+        (do (log/debug "Migrated new index file:" (:address next-file-event))
+            (recur))))))
+
+(defn migrate-alias
+  [conn commit-opts index-files-ch alias]
+  (go-try
+    (let [address (<? (nameservice/primary-address conn alias nil))]
+      (log/info "Migrating ledger" alias "at address" address)
+      (<? (sid/migrate conn address commit-opts index-files-ch)))))
 
 (defn sid-migrate-ledgers
-  [conn consensus-config commit-opts ledgers]
+  [conn commit-opts ledgers]
   (go-try
-    (let [index-files-ch (async/chan)
-          resp-ch        (async/chan)]
-      (push-migrated-index-files consensus-config index-files-ch resp-ch)
-      (loop [[alias & r] ledgers]
+    (loop [[alias & r] ledgers]
+      (let [index-files-ch (async/chan)
+            error-ch       (async/chan)]
+        (log-migrated-index-files index-files-ch error-ch)
         (if alias
-          (let [address (<? (nameservice/primary-address conn alias nil))]
-            (log/info "Migrating ledger" alias "at address" address)
-            (<? (sid/migrate conn address commit-opts index-files-ch))
-            (if-let [_resp (<? resp-ch)]
-              (do (log/info "Ledger" alias "migrated successfully")
-                  (recur r))
-              (log/info "Got no response from consensus group. Stopping migration.")))
-          (do (<? resp-ch)
-              (log/info "All ledgers migrated successfully")))))))
+          (let [migrate-ch (migrate-alias conn commit-opts index-files-ch alias)]
+            (async/alt!
+              error-ch   ([e]
+                          (throw e))
+
+              migrate-ch ([_ledger]
+                          (log/info "Ledger" alias "migrated successfully")))
+            (recur r))
+          (log/info "All ledgers migrated successfully"))))))
 
 (def sid-migrater
-  #::ds{:config {:fluree/connection       (ds/ref [:fluree :conn])
-                 :fluree/consensus-config (ds/ref [:env :fluree/consensus])
-                 :fluree/migrater         (ds/ref [:env :fluree/migrater])
-                 :fluree/commit-opts      (ds/ref [:env :fluree/commit-options])}
-        :start  (fn [{{:keys [fluree/connection fluree/consensus-config fluree/migrater
+  #::ds{:config {:fluree/connection  (ds/ref [:fluree :conn])
+                 :fluree/migrater    (ds/ref [:env :fluree/migrater])
+                 :fluree/commit-opts (ds/ref [:env :fluree/commit-options])}
+        :start  (fn [{{:keys [fluree/connection fluree/migrater
                              fluree/commit-opts]}
                      ::ds/config}]
-                  (<?? (sid-migrate-ledgers connection consensus-config commit-opts
-                                            (:ledgers migrater))))})
+                  (let [{:keys [ledgers]} migrater]
+                    (log/info "Beginning migration for ledger aliases:" ledgers)
+                    (<?? (sid-migrate-ledgers connection commit-opts ledgers))))})

--- a/src/fluree/server/components/migrate.clj
+++ b/src/fluree/server/components/migrate.clj
@@ -1,13 +1,13 @@
 (ns fluree.server.components.migrate
   (:require [clojure.core.async :as async :refer [<! >! go-loop]]
             [donut.system :as ds]
-            [fluree.server.consensus.raft.core :refer [is-leader?]]
-            [fluree.db.util.core :as util]
-            [fluree.db.util.async :refer [<?? <? go-try]]
             [fluree.db.json-ld.migrate.sid :as sid]
             [fluree.db.nameservice.core :as nameservice]
+            [fluree.db.util.async :refer [<?? <? go-try]]
+            [fluree.db.util.core :as util]
+            [fluree.db.util.log :as log]
             [fluree.server.consensus.producers.new-index-file :as new-index-file]
-            [fluree.db.util.log :as log]))
+            [fluree.server.consensus.raft.core :refer [is-leader?]]))
 
 ;; TODO: this function is unused, but would be necessary if migrating through
 ;; consensus
@@ -71,8 +71,8 @@
                  :fluree/migrater    (ds/ref [:env :fluree/migrater])
                  :fluree/commit-opts (ds/ref [:env :fluree/commit-options])}
         :start  (fn [{{:keys [fluree/connection fluree/migrater
-                             fluree/commit-opts]}
-                     ::ds/config}]
+                              fluree/commit-opts]}
+                      ::ds/config}]
                   (let [{:keys [ledgers]} migrater]
                     (log/info "Beginning migration for ledger aliases:" ledgers)
                     (<?? (sid-migrate-ledgers connection commit-opts ledgers))))})

--- a/src/fluree/server/consensus/core.clj
+++ b/src/fluree/server/consensus/core.clj
@@ -19,12 +19,11 @@
 (defn queue-new-ledger
   "Queues a new ledger into the consensus layer for processing.
   Returns a core async channel that will eventually contain true if successful."
-  [group conn-type ledger-id tx-id txn opts]
+  [group ledger-id tx-id txn opts]
   (log/debug "Consensus - queue new ledger:" ledger-id tx-id txn)
   (txproto/-new-entry-async
    group
    [:ledger-create {:txn         txn
-                    :conn-type   conn-type
                     :size        (count txn)
                     :tx-id       tx-id
                     :ledger-id   ledger-id
@@ -34,12 +33,11 @@
 (defn queue-new-transaction
   "Queues a new transaction into the consensus layer for processing.
   Returns a core async channel that will eventually contain a truthy value if successful."
-  [group conn-type ledger-id tx-id txn opts]
+  [group ledger-id tx-id txn opts]
   (log/trace "queue-new-transaction txn:" txn)
   (txproto/-new-entry-async
    group
    [:tx-queue {:txn            txn
-               :conn-type      conn-type
                :size           (count txn)
                :tx-id          tx-id
                :ledger-id      ledger-id

--- a/src/fluree/server/consensus/handlers/create_ledger.clj
+++ b/src/fluree/server/consensus/handlers/create_ledger.clj
@@ -5,7 +5,7 @@
             [fluree.db.util.log :as log]
             [fluree.raft.leader :refer [is-leader?]]
             [fluree.server.consensus.core :as consensus]
-            [fluree.server.consensus.producers.new-index-file :refer [push-new-index-files]]
+            [fluree.server.consensus.producers.new-index-file :as new-index-file]
             [fluree.server.consensus.raft.core :as raft]
             [fluree.server.handlers.shared :refer [deref!]]))
 
@@ -41,9 +41,7 @@
   (let [create-opts (parse-opts txn)
         ledger      (deref! (fluree/create conn ledger-id create-opts))
         commit!     (fn [db]
-                      (let [index-files-ch (async/chan)
-                            ;; monitor for new index files and push across network
-                            _              (push-new-index-files config index-files-ch)
+                      (let [index-files-ch (new-index-file/monitor-chan config)
                             resp           (fluree/commit! ledger db {:file-data?     true
                                                                       :index-files-ch index-files-ch})]
                         (log/debug "New ledger" ledger-id "created with tx-id: " tx-id)

--- a/src/fluree/server/consensus/handlers/create_ledger.clj
+++ b/src/fluree/server/consensus/handlers/create_ledger.clj
@@ -1,6 +1,5 @@
 (ns fluree.server.consensus.handlers.create-ledger
-  (:require [clojure.core.async :as async]
-            [fluree.db.constants :as const]
+  (:require [fluree.db.constants :as const]
             [fluree.db.json-ld.api :as fluree]
             [fluree.db.util.log :as log]
             [fluree.raft.leader :refer [is-leader?]]

--- a/src/fluree/server/consensus/handlers/create_ledger.clj
+++ b/src/fluree/server/consensus/handlers/create_ledger.clj
@@ -61,11 +61,10 @@
   Returns promise that will have the eventual response once committed."
   [{:keys [consensus/raft-state] :as config}
    {:keys [ledger-id tx-id] :as _params}
-   {:keys [db data-file-meta commit-file-meta context-file-meta]}]
+   {:keys [db data-file-meta commit-file-meta]}]
   (let [created-body {:ledger-id         ledger-id
                       :data-file-meta    data-file-meta
                       :commit-file-meta  commit-file-meta
-                      :context-file-meta context-file-meta
                       ;; below is metadata for quickly validating into the state machine, not retained
                       :t                 (:t db) ;; for quickly validating this is the next 'block'
                       :tx-id             tx-id ;; for quickly removing from the queue

--- a/src/fluree/server/consensus/handlers/new_commit.clj
+++ b/src/fluree/server/consensus/handlers/new_commit.clj
@@ -23,7 +23,7 @@
   local-storage. If using a networked file system (e.g. S3, IPFS) the
   file is already stored by the leader with the respective service."
   [{:keys [consensus/raft-state fluree/conn] :as config}
-   {:keys [data-file-meta commit-file-meta context-file-meta server] :as commit-result}]
+   {:keys [data-file-meta commit-file-meta server] :as commit-result}]
   (go-try
     (let [this-server (:this-server raft-state)]
       (when (not= server this-server)
@@ -31,8 +31,6 @@
         ;; were already written - only other servers need to write file
         (when data-file-meta ;; if the commit is just being updated, there won't be more data (e.g. after indexing)
           (write-file config data-file-meta))
-        (when context-file-meta
-          (write-file config context-file-meta))
         (write-file config commit-file-meta)
         (<? (nameservice/push! conn commit-file-meta)))
       commit-result)))

--- a/src/fluree/server/consensus/handlers/tx_queue.clj
+++ b/src/fluree/server/consensus/handlers/tx_queue.clj
@@ -15,7 +15,6 @@
   ;; fluree.server.consensus.core/queue-new-transaction
 
   '{:txn       txn
-    :conn-type conn-type
     :size      (count txn)
     :tx-id     tx-id
     :ledger-id ledger-id

--- a/src/fluree/server/consensus/producers/new_commit.clj
+++ b/src/fluree/server/consensus/producers/new_commit.clj
@@ -13,11 +13,10 @@
   Returns promise that will have the eventual response once committed."
   [{:keys [consensus/raft-state] :as config}
    {:keys [ledger-id tx-id] :as _params}
-   {:keys [db data-file-meta commit-file-meta context-file-meta]}]
+   {:keys [db data-file-meta commit-file-meta]}]
   (let [created-body {:ledger-id         ledger-id
                       :data-file-meta    data-file-meta
                       :commit-file-meta  commit-file-meta
-                      :context-file-meta context-file-meta
                       ;; below is metadata for quickly validating into the state machine, not retained
                       :t                 (:t db) ;; for quickly validating this is the next 'block'
                       :tx-id             tx-id ;; for quickly removing from the queue
@@ -35,11 +34,10 @@
   This is called with updated commits generated from the indexing process.
 
   Returns promise that will have the eventual response once committed."
-  [config {:keys [commit-res context-res db] :as _params}]
+  [config {:keys [commit-res db] :as _params}]
   (let [ledger    (:ledger db)
         ledger-id (ledger-proto/-alias ledger)]
     (consensus-push-commit config
                            {:ledger-id ledger-id}
                            {:db                db
-                            :context-file-meta context-res
                             :commit-file-meta  commit-res})))

--- a/src/fluree/server/consensus/producers/new_commit.clj
+++ b/src/fluree/server/consensus/producers/new_commit.clj
@@ -1,5 +1,5 @@
 (ns fluree.server.consensus.producers.new-commit
-  (:require [fluree.db.ledger.proto :as ledger-proto]
+  (:require [fluree.db.ledger :as ledger]
             [fluree.server.consensus.core :as consensus]
             [fluree.server.consensus.raft.core :as raft]))
 
@@ -36,7 +36,7 @@
   Returns promise that will have the eventual response once committed."
   [config {:keys [commit-res db] :as _params}]
   (let [ledger    (:ledger db)
-        ledger-id (ledger-proto/-alias ledger)]
+        ledger-id (ledger/-alias ledger)]
     (consensus-push-commit config
                            {:ledger-id ledger-id}
                            {:db                db

--- a/src/fluree/server/consensus/producers/new_index_file.clj
+++ b/src/fluree/server/consensus/producers/new_index_file.clj
@@ -38,7 +38,15 @@
               :new-commit (consensus-push-index-commit config (:data next-file-event)))
             (recur)))))))
 
+(def index-file-xf
+  (map (fn [event-data]
+         (assoc event-data :event :new-index-file))))
+
 (defn monitor-chan
   [config]
-  (doto (async/chan)
+  (doto (async/chan 512 index-file-xf) ; The buffer prevents the consensus group
+                                       ; from slowing the indexer's progress
+                                       ; initially while still allowing the
+                                       ; group to catch up if it falls too far
+                                       ; behind
     (push-new-index-files config)))

--- a/src/fluree/server/consensus/producers/new_index_file.clj
+++ b/src/fluree/server/consensus/producers/new_index_file.clj
@@ -38,15 +38,9 @@
               :new-commit (consensus-push-index-commit config (:data next-file-event)))
             (recur)))))))
 
-(def index-file-xf
-  (map (fn [event-data]
-         (assoc event-data :event :new-index-file))))
-
 (defn monitor-chan
   [config]
-  (doto (async/chan 512 index-file-xf) ; The buffer prevents the consensus group
-                                       ; from slowing the indexer's progress
-                                       ; initially while still allowing the
-                                       ; group to catch up if it falls too far
-                                       ; behind
+  (doto (async/chan 512) ; The buffer prevents the consensus group from slowing
+                         ; the indexer's progress initially while still allowing
+                         ; the group to catch up if it falls too far behind
     (push-new-index-files config)))

--- a/src/fluree/server/handlers/create.clj
+++ b/src/fluree/server/handlers/create.clj
@@ -1,7 +1,6 @@
 (ns fluree.server.handlers.create
   (:require
    [clojure.core.async :as async :refer [go <!]]
-   [fluree.db.conn.proto :as conn-proto]
    [fluree.db.constants :as const]
    [fluree.db.json-ld.api :as fluree]
    [fluree.db.util.context :as ctx-util]
@@ -17,9 +16,8 @@
 
 (defn queue-consensus
   [consensus conn watcher ledger tx-id txn opts]
-  (let [conn-type       (conn-proto/-method conn)
-        ;; initial response is not completion, but acknowledgement of persistence
-        persist-resp-ch (consensus/queue-new-ledger consensus conn-type ledger tx-id txn opts)]
+  (let [;; initial response is not completion, but acknowledgement of persistence
+        persist-resp-ch (consensus/queue-new-ledger consensus ledger tx-id txn opts)]
 
     (go
       (let [persist-resp (<! persist-resp-ch)]

--- a/src/fluree/server/handlers/create.clj
+++ b/src/fluree/server/handlers/create.clj
@@ -60,7 +60,7 @@
             (log/info "Ledger created:" ledger-id)
             (deliver p {:ledger ledger-id
                         :commit (:address commit-file-meta)
-                        :t      (- t)
+                        :t      t
                         :tx-id  tx-id})))))))
 
 (defn throw-ledger-exists

--- a/src/fluree/server/handlers/remote_resource.clj
+++ b/src/fluree/server/handlers/remote_resource.clj
@@ -1,36 +1,14 @@
 (ns fluree.server.handlers.remote-resource
-  (:require [clojure.string :as str]
-            [fluree.db.conn.proto :as conn-proto]
-            [fluree.db.json-ld.api :as-alias fluree]
+  (:require [fluree.db.json-ld.api :as-alias fluree]
             [fluree.db.nameservice.core :as nameservice]
-            [fluree.db.util.async :refer [<? <?? go-try]]
+            [fluree.db.util.async :refer [<??]]
             [fluree.db.util.log :as log]
             [fluree.server.handlers.shared :refer [defhandler]]))
 
-(defn read-latest-commit
-  [conn resource-name]
-  (go-try
-    (let [commit-addr (<? (nameservice/lookup-commit conn resource-name))
-          _           (when-not commit-addr
-                        (throw (ex-info (str "Unable to load. No commit exists for: " alias)
-                                        {:status 400 :error :db/invalid-commit-address})))
-          commit-data (<? (conn-proto/-c-read conn commit-addr))]
-      (assoc commit-data "address" commit-addr))))
-
-(defn resource-address
-  [conn resource-name]
-  (if (str/starts-with? resource-name "fluree:")
-    resource-name
-    (str "fluree:" (name (conn-proto/-method conn)) "://" resource-name)))
-
 (defhandler read-handler
   [{:keys [fluree/conn]
-    {{resource-name :resource :as body} :body} :parameters}]
+    {{resource-address :resource :as body} :body} :parameters}]
   (log/debug "Remote resource read request:" body)
-  (let [resource-address (resource-address conn resource-name)
-        file-read?       (str/ends-with? resource-address ".json")
-        result           (if file-read?
-                           (<?? (conn-proto/-c-read conn resource-address))
-                           (<?? (read-latest-commit conn resource-address)))]
+  (let [result (<?? (nameservice/read-resource conn resource-address))]
     {:status 200
      :body   result}))

--- a/src/fluree/server/handlers/remote_resource.clj
+++ b/src/fluree/server/handlers/remote_resource.clj
@@ -10,7 +10,7 @@
 (defn read-latest-commit
   [conn resource-name]
   (go-try
-    (let [commit-addr (<? (nameservice/lookup-commit conn resource-name nil))
+    (let [commit-addr (<? (nameservice/lookup-commit conn resource-name))
           _           (when-not commit-addr
                         (throw (ex-info (str "Unable to load. No commit exists for: " alias)
                                         {:status 400 :error :db/invalid-commit-address})))

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -67,7 +67,7 @@
                       "commit head:" (:address commit-file-meta))
             (deliver p {:ledger ledger-id
                         :commit (:address commit-file-meta)
-                        :t      (- t)
+                        :t      t
                         :tx-id  tx-id})))))))
 
 (defn throw-ledger-doesnt-exist

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -1,7 +1,6 @@
 (ns fluree.server.handlers.transact
   (:require [clojure.core.async :as async]
             [fluree.crypto :as crypto]
-            [fluree.db.conn.proto :as conn-proto]
             [fluree.db.constants :as const]
             [fluree.db.json-ld.api :as fluree]
             [fluree.db.util.context :as ctx-util]
@@ -20,9 +19,8 @@
 
 (defn queue-consensus
   [consensus conn watcher ledger tx-id expanded-txn opts]
-  (let [conn-type       (conn-proto/-method conn)
-        ;; initial response is not completion, but acknowledgement of persistence
-        persist-resp-ch (consensus/queue-new-transaction consensus conn-type ledger tx-id
+  (let [;; initial response is not completion, but acknowledgement of persistence
+        persist-resp-ch (consensus/queue-new-transaction consensus ledger tx-id
                                                          expanded-txn opts)]
     (async/go
       (let [persist-resp (async/<! persist-resp-ch)]

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -18,7 +18,7 @@
   (-> txn jld-processor/canonize (crypto/sha2-256 :hex :string)))
 
 (defn queue-consensus
-  [consensus conn watcher ledger tx-id expanded-txn opts]
+  [consensus watcher ledger tx-id expanded-txn opts]
   (let [;; initial response is not completion, but acknowledgement of persistence
         persist-resp-ch (consensus/queue-new-transaction consensus ledger tx-id
                                                          expanded-txn opts)]
@@ -30,13 +30,13 @@
           (watcher/deliver-watch watcher tx-id persist-resp))))))
 
 (defn transact!
-  [p consensus conn watcher expanded-txn opts]
+  [p consensus watcher expanded-txn opts]
   (let [ledger-id     (-> expanded-txn (get const/iri-ledger) (get 0) (get "@value"))
         tx-id         (derive-tx-id expanded-txn)
         final-resp-ch (watcher/create-watch watcher tx-id)]
 
     ;; register transaction into consensus
-    (queue-consensus consensus conn watcher ledger-id tx-id expanded-txn opts)
+    (queue-consensus consensus watcher ledger-id tx-id expanded-txn opts)
 
     ;; wait for final response from consensus and deliver to promise
     (async/go
@@ -88,8 +88,8 @@
     (or (deref! (fluree/exists? conn ledger-id))
         (throw-ledger-doesnt-exist ledger-id))
     ;; kick of async process that will eventually deliver resp or exception to resp-p
-    (transact! resp-p consensus conn watcher expanded-txn (cond-> {:context txn-context}
-                                                            did (assoc :did did)))
+    (transact! resp-p consensus watcher expanded-txn (cond-> {:context txn-context}
+                                                       did (assoc :did did)))
 
     {:status 200
      :body   (deref! resp-p)}))

--- a/src/fluree/server/main.clj
+++ b/src/fluree/server/main.clj
@@ -92,9 +92,11 @@
 
 (defmethod ds/named-system :migrate
   [_]
-  (ds/system :base {[:http :server]     ::disabled
-                    [:http :handler]    ::disabled
-                    [:fluree :migrator] migrate/sid-migrater}))
+  (ds/system :base {[:http :server]      ::disabled
+                    [:http :handler]     ::disabled
+                    [:fluree :consensus] ::disabled
+                    [:fluree :watcher]   ::disabled
+                    [:fluree :migrator]  migrate/sid-migrater}))
 
 (defmethod ds/named-system :migrate/prod
   [_]

--- a/src/fluree/server/main.clj
+++ b/src/fluree/server/main.clj
@@ -8,9 +8,9 @@
             [fluree.server.components.consensus :as consensus]
             [fluree.server.components.fluree :as fluree]
             [fluree.server.components.http :as http]
+            [fluree.server.components.migrate :as migrate]
             [fluree.server.components.subscriptions :as subscriptions]
             [fluree.server.components.watcher :as watcher]
-            [fluree.server.components.migrate :as migrate]
             [jsonista.core :as json])
   (:import (java.io PushbackReader))
   (:gen-class))

--- a/src/fluree/server/main.clj
+++ b/src/fluree/server/main.clj
@@ -10,6 +10,7 @@
             [fluree.server.components.http :as http]
             [fluree.server.components.subscriptions :as subscriptions]
             [fluree.server.components.watcher :as watcher]
+            [fluree.server.components.migrate :as migrate]
             [jsonista.core :as json])
   (:import (java.io PushbackReader))
   (:gen-class))
@@ -81,6 +82,11 @@
 (defmethod ds/named-system :docker
   [_]
   (ds/system :prod {[:env] (env-config :docker)}))
+
+(defmethod ds/named-system :migrate
+  [_]
+  (ds/system {[:http]     ::disabled
+              [:migrator] migrate/sid-migrator}))
 
 (defn run-server
   "Runs an HTTP API server in a thread, with :profile from opts or :dev by

--- a/test/fluree/server/integration/basic_transaction_test.clj
+++ b/test/fluree/server/integration/basic_transaction_test.clj
@@ -165,7 +165,7 @@
       (is (= 200
              (-> (api-post :transact {:body (json/write-value-as-string req2) :headers json-headers})
                  :status)))
-      (is (= [{"id" "ex:list-test"}]
+      (is (= []
              (-> (api-post :query {:body (json/write-value-as-string q1) :headers json-headers})
                  :body
                  json/read-value))))))


### PR DESCRIPTION
This patch updates server work with the db library using SID objects introduced in fluree/db#660. The api is very similar on the db side, so the only things that had to change here are (1) removing the negation of t-values in commit responses because those values are now always positive, and (2) removing the expectation that the "id" attribute will exist after a deletion because we no longer have "id" flakes in the db.