### PR TITLE
Add `:remote` profile configuration

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -52,6 +52,14 @@
   :run-dev
   {:exec-fn   fluree.server.main/run-server
    :exec-args {:profile :dev}}
+  
+  :run-docker
+  {:exec-fn   fluree.server.main/run-server
+   :exec-args {:profile :docker}}
+  
+  :run-remote
+  {:exec-fn   fluree.server.main/run-server
+   :exec-args {:profile :remote}}
 
   :test
   {:extra-paths ["test"]

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,52 +1,59 @@
 {:http/server       {:port           #long #or [#env FLUREE_HTTP_API_PORT
                                                 #profile {:dev    58090
+                                                          :remote 8091
                                                           :prod   8090
                                                           :docker 8090}]
                      :max-tx-wait-ms #or [#env FLUREE_HTTP_MAX_TX_WAIT_MS
                                           #profile {:dev    45000
+                                                    :remote 45000
                                                     :prod   45000
                                                     :docker 45000}]}
  :fluree/connection {:remote-servers #or [#env FLUREE_REMOTE_SERVERS
-                                          #profile {:dev    "http://127.0.0.1:58090"
+                                          #profile {:dev    nil
+                                                    :remote "http://127.0.0.1:8091"
+                                                    :prod   nil
+                                                    :docker nil}]
+                     :servers        #or [#env FLUREE_SERVERS
+                                          #profile {:dev    nil
+                                                    :remote "http://127.0.0.1:8091"
                                                     :prod   nil
                                                     :docker nil}]
                      :method         #or [#env FLUREE_STORAGE_METHOD
                                           #profile {:dev    :file
+                                                    :remote :remote
                                                     :prod   :file
                                                     :docker :file}]
                      :parallelism    #or [#env FLUREE_CONN_PARALLELISM
                                           #profile {:dev    1
+                                                    :remote 1
                                                     :prod   4
                                                     :docker 4}]
                      :storage-path   #or [#env FLUREE_STORAGE_PATH
                                           #profile {:dev    "data"
+                                                    :remote "data"
                                                     :prod   "data"
                                                     :docker "data"}]
                      :cache-max-mb   #or [#env FLUREE_CACHE_MAX_MB ;; integer, in MB
                                           #profile {:dev    100
+                                                    :remote 100
                                                     :prod   1000
                                                     :docker 1000}]
                      :defaults       {:context-type :string
                                       :indexer      {:reindex-min-bytes 1000
-                                                     :reindex-max-bytes 10000000}
-                                      :context
-                                      #or [#env FLUREE_DEFAULT_CONTEXT
-                                           #include-json-or-edn #env FLUREE_DEFAULT_CONTEXT_FILE
-                                           #profile {:dev
-                                                     {:id   "@id"
-                                                      :type "@type"
-                                                      :ex   "http://example.com/"
-                                                      :f    "https://ns.flur.ee/ledger#"}}]}}
+                                                     :reindex-max-bytes 10000000}}}
  :fluree/consensus  {:consensus-servers     #or [#env FLUREE_CONSENSUS_SERVERS
                                                  #profile {:dev    "/ip4/127.0.0.1/tcp/62071"
+                                                           :remote nil
                                                            :prod   nil
                                                            :docker "/ip4/127.0.0.1/tcp/62071"}]
                      :consensus-this-server #or [#env FLUREE_CONSENSUS_THIS_SERVER
-                                                 #profile {:dev    "/ip4/127.0.0.1/tcp/62071"
+                                                 #profile {:dev    "/ip4/127.0.0.1/tcp/62071" 
+                                                           :remote nil
                                                            :prod   nil
                                                            :docker "/ip4/127.0.0.1/tcp/62071"}]
                      :consensus-type        #or [#env FLUREE_CONSENSUS_TYPE
-                                                 #profile {:dev    :raft
+                                                 #profile {:dev    :raft 
+                                                           :remote :none
                                                            :prod   :raft
                                                            :docker :raft}]
                      ;; TODO - trace down both uses of private-key vs private-keys reconcile

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -10,12 +10,12 @@
                                                     :docker 45000}]}
  :fluree/connection {:remote-servers #or [#env FLUREE_REMOTE_SERVERS
                                           #profile {:dev    nil
-                                                    :remote "http://127.0.0.1:8091"
+                                                    :remote "http://127.0.0.1:8090"
                                                     :prod   nil
                                                     :docker nil}]
                      :servers        #or [#env FLUREE_SERVERS
                                           #profile {:dev    nil
-                                                    :remote "http://127.0.0.1:8091"
+                                                    :remote "http://127.0.0.1:8090"
                                                     :prod   nil
                                                     :docker nil}]
                      :method         #or [#env FLUREE_STORAGE_METHOD


### PR DESCRIPTION
In addition to adding a `:remote` profile to `config.edn` and an alias for running as `:remote` to `deps.edn`, also removed stale config for a `DEFAULT CONTEXT`