### PR TITLE
Allow running linters on existing code

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,13 @@ The most common environment variables to set would include:
 
 Run `make prepare` to compile the required dependencies to enable Clojure development.
 
+### Code linting
+
+- Code linters can be run via `bb run lint`
+    - This will run cljfmt and clj-kondo on the entire codebase
+
 ### Git hooks
 
 - Run `bb run git-hooks install`
     - This will set up a pre-commit git hook that checks your staged changes
-      with cljfmt and clj-kondo.
+      with cljfmt and clj-kondo before allowing them to be committed.

--- a/bb.edn
+++ b/bb.edn
@@ -3,4 +3,6 @@
  :deps  {dev.weavejester/cljfmt {:git/url "https://github.com/cap10morgan/cljfmt.git"
                                  :git/sha "61841ae45c5a6ff7e1fa0b4bc284c3af54f4324b"}}
  :tasks {git-hooks {:requires ([git-hooks :as gh])
-                    :task     (apply gh/hook *command-line-args*)}}}
+                    :task     (apply gh/hook *command-line-args*)}
+         lint      {:requires ([lint])
+                    :task     (lint/run-all ".")}}}

--- a/bb/git_hooks.clj
+++ b/bb/git_hooks.clj
@@ -1,10 +1,7 @@
 (ns git-hooks
   (:require [babashka.fs :as fs]
-            [clojure.edn :as edn]
-            [clojure.string :as str]
-            [lib.clj-kondo :as clj-kondo]
-            [lib.cljfmt :as cljfmt]
-            [lib.git :as git])
+            [lib.git :as git]
+            [lint])
   (:import (java.util Date)))
 
 ;; originally inspired by https://blaster.ai/blog/posts/manage-git-hooks-w-babashka.html
@@ -36,44 +33,6 @@ bb git-hooks %s" (Date.) hook))
   [& args]
   (println "Unknown git hook:" (first args)))
 
-;; checks
-
-(defn- check-enabled?
-  [check]
-  (let [skip-checks      (System/getenv "SKIP_CHECKS")
-        skip-checks-coll (when skip-checks
-                           (edn/read-string
-                            (if (str/starts-with? skip-checks "[")
-                              skip-checks
-                              (str "[" skip-checks "]"))))
-        disabled-checks  (into #{} (map keyword) skip-checks-coll)]
-    (not (contains? disabled-checks check))))
-
-(defmulti check (fn [& args] (-> args first keyword)))
-
-(defmethod check :cljfmt
-  [_ staging-dir]
-  (let [bad-files (cljfmt/check staging-dir)]
-    (when (and (check-enabled? :cljfmt) (seq bad-files))
-      (println)
-      (println (let [bfc (count bad-files)]
-                 (str bfc " " (if (= 1 bfc) "file is" "files are")
-                      " formatted incorrectly:\n"
-                      (str/join "\n" bad-files)
-                      "\n")))
-      (println "Run: cljfmt fix" (str/join " " bad-files))
-      (println "     git add" (str/join " " bad-files))
-      (println)
-      (System/exit 1))))
-
-(defmethod check :clj-kondo
-  [_ staging-dir]
-  (let [bad-files (clj-kondo/lint staging-dir)]
-    (when (and (check-enabled? :clj-kondo) (seq bad-files))
-      (println)
-      (println "Fix errors and run: git add" (str/join " " bad-files))
-      (System/exit 2))))
-
 ;; hooks
 
 (defmulti hook (fn [& args] (-> args first keyword)))
@@ -88,8 +47,8 @@ bb git-hooks %s" (Date.) hook))
   (when-let [files (git/changed-files)]
     (println "Found" (count files) "changed files\n")
     (let [staging-dir (git/staged-contents files)]
-      (check :cljfmt staging-dir)
-      (check :clj-kondo staging-dir))
+      (lint/check :cljfmt staging-dir)
+      (lint/check :clj-kondo staging-dir))
     (println)
     (println "🤘 Commit looks good! 🤘")))
 

--- a/bb/lint.clj
+++ b/bb/lint.clj
@@ -1,0 +1,50 @@
+(ns lint
+  (:require [babashka.fs :as fs]
+            [clojure.edn :as edn]
+            [clojure.string :as str]
+            [lib.clj-kondo :as clj-kondo]
+            [lib.cljfmt :as cljfmt]))
+
+(defn- check-enabled?
+  [check]
+  (let [skip-checks      (System/getenv "SKIP_CHECKS")
+        skip-checks-coll (when skip-checks
+                           (edn/read-string
+                            (if (str/starts-with? skip-checks "[")
+                              skip-checks
+                              (str "[" skip-checks "]"))))
+        disabled-checks  (into #{} (map keyword) skip-checks-coll)]
+    (not (contains? disabled-checks check))))
+
+(defmulti check (fn [& args] (-> args first keyword)))
+
+(defmethod check :cljfmt
+  [_ staging-dir]
+  (let [bad-files (cljfmt/check staging-dir)]
+    (when (and (check-enabled? :cljfmt) (seq bad-files))
+      (println)
+      (println (let [bfc (count bad-files)]
+                 (str bfc " " (if (= 1 bfc) "file is" "files are")
+                      " formatted incorrectly:\n"
+                      (str/join "\n" bad-files)
+                      "\n")))
+      (println "Run: cljfmt fix" (str/join " " bad-files))
+      (println "     git add" (str/join " " bad-files))
+      (println)
+      (System/exit 1))))
+
+(defmethod check :clj-kondo
+  [_ staging-dir]
+  (let [bad-files (clj-kondo/lint staging-dir)]
+    (when (and (check-enabled? :clj-kondo) (seq bad-files))
+      (println)
+      (println "Fix errors and run: git add" (str/join " " bad-files))
+      (System/exit 2))))
+
+(defn run-all
+  "Runs all enabled linters at root `dir`"
+  [dir]
+  (let [path (-> dir fs/file fs/canonicalize str)]
+    (println "Linting" path)
+    (check :cljfmt path)
+    (check :clj-kondo path)))


### PR DESCRIPTION
Same as the :pre-commit git hook, but sometimes you want to lint what’s already there.