### PR TITLE
Update GitHub workflow deps to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,12 @@ jobs:
     name: cljfmt check
     runs-on: [ linux, large ]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'
-      - uses: DeLaGuardo/setup-clojure@12.1
+      - uses: DeLaGuardo/setup-clojure@12.5
         with:
           cljfmt: 'latest'
       - run: make cljfmt-check
@@ -39,8 +39,8 @@ jobs:
     name: clj-kondo lint
     runs-on: [ linux, large ]
     steps:
-      - uses: actions/checkout@v3
-      - uses: DeLaGuardo/setup-clojure@12.1
+      - uses: actions/checkout@v4
+      - uses: DeLaGuardo/setup-clojure@12.5
         with:
           clj-kondo: 'latest'
       - run: make clj-kondo-lint-ci


### PR DESCRIPTION
This will fail in CI too, but the next PR up the stack should succeed. Probably should have done them in reverse order I guess...