### PR TITLE
feat: Add user fluree to run the container as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,26 @@ RUN clojure -T:build uber
 
 FROM eclipse-temurin:17-jre-jammy AS runner
 
-RUN mkdir -p /opt/fluree-server
-WORKDIR /opt/fluree-server
+# Read here why UID 10001: https://github.com/hexops/dockerfile/blob/main/README.md#do-not-use-a-uid-below-10000
+ARG USER_NAME=fluree
+ARG USER_UID=10001
+ARG USER_GID=${USER_UID}
+ENV FLUREE_HOME=/opt/fluree-server
 
-COPY --from=builder /usr/src/fluree-server/target/server-*.jar ./server.jar
+WORKDIR ${FLUREE_HOME}
+
+# Creates a user with $UID and $GID=$UID
+RUN groupadd --gid ${USER_GID} ${USER_NAME} && \
+    useradd -m -s /bin/bash \
+    -d ${FLUREE_HOME} \
+    -u ${USER_UID} \
+    -g ${USER_GID} ${USER_NAME} &&\
+    mkdir -p ${FLUREE_HOME}/data &&\
+    chown -R ${USER_NAME}:${USER_NAME} ${FLUREE_HOME}/data
+
+USER ${USER_NAME}
+
+COPY --from=builder --chown=${USER_NAME}:${USER_NAME} /usr/src/fluree-server/target/server-*.jar ./server.jar
 
 EXPOSE 8090
 EXPOSE 58090


### PR DESCRIPTION
hello!

I've added the user `fluree` (10001) to run the container as non-root.

Tested and working:
```bash
... [async-dispatch-6] INFO  fluree.server.consensus.raft.core - Ledger group leader change: {:cause :become-leader, :server "/ip4/127.0.0.1/tcp/62071", :new-leader "/ip4/127.0.0.1/tcp/62071", :old-leader nil, :event :become-leader, :message "This server, /ip4/127.0.0.1/tcp/62071, received the majority of the votes to become leader. New term: 1, latest index: 0."}
Fluree HTTP API server running on port 8090
```

cheers! 🚀 