### PR TITLE
support query-string t val in from, from-named

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps  {org.clojure/clojure            {:mvn/version "1.11.2"}
          org.clojure/core.async         {:mvn/version "1.6.681"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "478c4fe92bbc28691d331bff72243618aa067a46"}
+                                         :git/sha "050e230e26be5edc933bd3db823ffa029ec0ac70"}
          com.fluree/json-ld             {:git/url "https://github.com/fluree/json-ld.git"
                                          :git/sha "0958995acf5540271d1807fc6d8f2da131164e24"}
 


### PR DESCRIPTION
Incorporates the new query-string t value syntax in fluree/db as per this PR:
https://github.com/fluree/db/pull/761

The functionality is exposed through the `/query` API allowing query `from` and `from-named` keys to specify t values as per the following example:

- my/db?t=42
- my/db?t=2020-01-01T00:00:00Z

Adds a test
