### PR TITLE
Fix/remove db ledger dependency

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps  {org.clojure/clojure            {:mvn/version "1.11.3"}
          org.clojure/core.async         {:mvn/version "1.6.681"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "74bc6775c11cd740263e527f756d3ab18c60d6b0"}
+                                         :git/sha "9be531997298ee320d7d7bfac26f0fcd7ab24db7"}
          com.fluree/json-ld             {:git/url "https://github.com/fluree/json-ld.git"
                                          :git/sha "0958995acf5540271d1807fc6d8f2da131164e24"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps  {org.clojure/clojure            {:mvn/version "1.11.3"}
          org.clojure/core.async         {:mvn/version "1.6.681"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "9be531997298ee320d7d7bfac26f0fcd7ab24db7"}
+                                         :git/sha "47674e9e7f8d8fb9754a714defc3dfab03cb71bb"}
          com.fluree/json-ld             {:git/url "https://github.com/fluree/json-ld.git"
                                          :git/sha "0958995acf5540271d1807fc6d8f2da131164e24"}
 

--- a/src/fluree/server/components/migrate.clj
+++ b/src/fluree/server/components/migrate.clj
@@ -43,9 +43,9 @@
 (defn migrate-alias
   [conn commit-opts index-files-ch alias]
   #_(go-try
-    (let [address (<? (nameservice/primary-address conn alias nil))]
-      (log/info "Migrating ledger" alias "at address" address)
-      (<? (sid/migrate conn address commit-opts index-files-ch)))))
+      (let [address (<? (nameservice/primary-address conn alias nil))]
+        (log/info "Migrating ledger" alias "at address" address)
+        (<? (sid/migrate conn address commit-opts index-files-ch)))))
 
 (defn sid-migrate-ledgers
   [conn commit-opts ledgers]

--- a/src/fluree/server/components/migrate.clj
+++ b/src/fluree/server/components/migrate.clj
@@ -42,7 +42,7 @@
 
 (defn migrate-alias
   [conn commit-opts index-files-ch alias]
-  (go-try
+  #_(go-try
     (let [address (<? (nameservice/primary-address conn alias nil))]
       (log/info "Migrating ledger" alias "at address" address)
       (<? (sid/migrate conn address commit-opts index-files-ch)))))

--- a/src/fluree/server/consensus/raft/producers/new_commit.clj
+++ b/src/fluree/server/consensus/raft/producers/new_commit.clj
@@ -1,6 +1,5 @@
 (ns fluree.server.consensus.raft.producers.new-commit
-  (:require [fluree.db.ledger :as ledger]
-            [fluree.server.consensus.raft.participant :as participant]))
+  (:require [fluree.server.consensus.raft.participant :as participant]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/fluree/server/consensus/raft/producers/new_commit.clj
+++ b/src/fluree/server/consensus/raft/producers/new_commit.clj
@@ -34,9 +34,7 @@
 
   Returns promise that will have the eventual response once committed."
   [config {:keys [commit-res db] :as _params}]
-  (let [ledger    (:ledger db)
-        ledger-id (ledger/-alias ledger)]
-    (consensus-push-commit config
-                           {:ledger-id ledger-id}
-                           {:db                db
-                            :commit-file-meta  commit-res})))
+  (consensus-push-commit config
+                         {:ledger-id (:alias db)}
+                         {:db                db
+                          :commit-file-meta  commit-res}))


### PR DESCRIPTION
This updates to the latest fluree/db sha, and removes a dependency on server that required (:ledger db) to be available which it no longer is.
