### PR TITLE
Tell clj-kondo to ignore migrate ns for now

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,1 +1,3 @@
-{:lint-as {fluree.server.handlers.shared/defhandler clojure.core/defn}}
+{:lint-as {fluree.server.handlers.shared/defhandler clojure.core/defn}
+ ;; TODO: Remove this when the migrate ns works again
+ :exclude-files "src/fluree/server/components/migrate.clj$"}


### PR DESCRIPTION
It does not like the current partially commented-out situation: https://github.com/fluree/server/actions/runs/9150600687/job/25155568632