### PR TITLE
Handle "fluree-role" header for queries

### DIFF
--- a/src/fluree/server/components/http.clj
+++ b/src/fluree/server/components/http.clj
@@ -189,7 +189,8 @@
   [handler]
   (fn [{:keys [body-params] :as req}]
     (log/trace "unwrap-credential body-params:" body-params)
-    (let [verified (<!! (cred/verify body-params))
+    (let [role (get-in req [:headers "fluree-role"])
+          verified (<!! (cred/verify body-params))
           _        (log/trace "unwrap-credential verified:" verified)
 
           {:keys [subject did]}
@@ -203,7 +204,7 @@
                 (throw (ex-info "Invalid credential"
                                 {:response {:status 400
                                             :body   {:error "Invalid credential"}}})))
-          req*     (assoc req :body-params subject :credential/did did :raw-txn body-params)]
+          req*     (assoc req :body-params subject :credential/did did :credential/role role :raw-txn body-params)]
       (log/debug "Unwrapped credential with did:" did)
       (handler req*))))
 

--- a/src/fluree/server/handlers/ledger.clj
+++ b/src/fluree/server/handlers/ledger.clj
@@ -6,17 +6,14 @@
    [fluree.server.handlers.shared :refer [defhandler deref!]]))
 
 (defhandler query
-  [{:keys [fluree/conn credential/did]
+  [{:keys [fluree/conn credential/did credential/role]
     {:keys [body]} :parameters}]
-  (let [query  (or (::http/query body) body)
-        format (or (::http/format body) :fql)
-        _      (log/debug "query handler received query:" query)
-        opts   (when (= :fql format)
-                 (cond-> (:opts query)
-                   did (assoc :did did)))
-        query* (if opts (assoc query :opts opts) query)]
+  (let [query        (or (::http/query body) body)
+        format       (or (::http/format body) :fql)
+        _            (log/debug "query handler received query:" query)
+        request-opts {:format format :did did :role role}]
     {:status 200
-     :body   (deref! (fluree/query-connection conn query* {:format format}))}))
+     :body   (deref! (fluree/query-connection conn query request-opts))}))
 
 (defhandler history
   [{:keys [fluree/conn credential/did]


### PR DESCRIPTION
This allows roles to be used in SPARQL queries.