### PR TITLE
Fix policy API tests

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps  {org.clojure/clojure            {:mvn/version "1.11.3"}
          org.clojure/core.async         {:mvn/version "1.6.681"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "82136ea134273c17633c90205c27efd1ff4bc18b"}
+                                         :git/sha "6bfc29a51da22dad60352a3e03b1588ce25c121f"}
          com.fluree/json-ld             {:git/url "https://github.com/fluree/json-ld.git"
                                          :git/sha "0958995acf5540271d1807fc6d8f2da131164e24"}
 

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -2,7 +2,6 @@
   (:require [clojure.string :as str]
             [fluree.server.handlers.transact :as tx-handler]
             [fluree.server.handlers.create :as create-handler]
-            [fluree.server.components.consensus :as consensus]
             [fluree.server.consensus.raft.handler :as consensus-handler]
             [fluree.server.consensus.raft]
             [clojure.java.io :as io]

--- a/test/fluree/server/integration/credential_test.clj
+++ b/test/fluree/server/integration/credential_test.clj
@@ -69,7 +69,8 @@
                              "from"     ledger-name
                              "select"   {"?t" ["*"]}
                              "where"    {"@id"  "?t"
-                                         "type" "schema:Test"}}
+                                         "type" "schema:Test"}
+                             "opts"     {"default-allow?" true}}
                             (:private auth)))
             query-res (api-post :query
                                 {:body    (json/write-value-as-string query-req)

--- a/test/fluree/server/integration/policy_test.clj
+++ b/test/fluree/server/integration/policy_test.clj
@@ -63,8 +63,8 @@
           query-req    {:body
                         (json/write-value-as-string
                          (assoc secret-query
-                           "opts" {"did"            alice-did
-                                   "default-allow?" true}))
+                                "opts" {"did"            alice-did
+                                        "default-allow?" true}))
                         :headers json-headers}
           query-res    (api-post :query query-req)]
 
@@ -92,8 +92,8 @@
             query-req {:body
                        (json/write-value-as-string
                         (assoc secret-query
-                          "opts" {"did"            alice-did
-                                  "default-allow?" true}))
+                               "opts" {"did"            alice-did
+                                       "default-allow?" true}))
                        :headers json-headers}
             query-res (api-post :query query-req)
             _         (assert (= 200 (:status query-res)))]

--- a/test/fluree/server/integration/policy_test.clj
+++ b/test/fluree/server/integration/policy_test.clj
@@ -63,7 +63,8 @@
           query-req    {:body
                         (json/write-value-as-string
                          (assoc secret-query
-                                "opts" {"did" alice-did}))
+                           "opts" {"did"            alice-did
+                                   "default-allow?" true}))
                         :headers json-headers}
           query-res    (api-post :query query-req)]
 
@@ -91,7 +92,8 @@
             query-req {:body
                        (json/write-value-as-string
                         (assoc secret-query
-                               "opts" {"did" alice-did}))
+                          "opts" {"did"            alice-did
+                                  "default-allow?" true}))
                        :headers json-headers}
             query-res (api-post :query query-req)
             _         (assert (= 200 (:status query-res)))]


### PR DESCRIPTION
With some recent changes, policy related tests were failing.

This is because the tests depend on the `:default-allow? true` setting which was getting set previously.

This updates the failing tests to explicitly include that flag.

The `zero-trust` mode will allow server (and maybe ledger?) level enforcement of this setting, but isn't yet available.