### PR TITLE
Standalone consensus component

### DIFF
--- a/resources/config-raft.edn
+++ b/resources/config-raft.edn
@@ -1,0 +1,21 @@
+{:fluree/raft {:log-history      #or [#env FLUREE_RAFT_LOG_HISTORY
+                                      10]
+               :entries-max      #or [#env FLUREE_RAFT_ENTRIES_MAX
+                                      50]
+               :catch-up-rounds  #or [#env FLUREE_RAFT_CATCH_UP_ROUNDS
+                                      10]
+               :storage-type     #or [#keyword #env FLUREE_RAFT_STORAGE_TYPE
+                                      :file]
+               :servers          #or [#env FLUREE_RAFT_SERVERS
+                                      #profile {:dev    "/ip4/127.0.0.1/tcp/62071"
+                                                :prod   nil
+                                                :docker "/ip4/127.0.0.1/tcp/62071"}]
+               :this-server      #or [#env FLUREE_RAFT_THIS_SERVER
+                                      #profile {:dev    "/ip4/127.0.0.1/tcp/62071"
+                                                :prod   nil
+                                                :docker "/ip4/127.0.0.1/tcp/62071"}]
+               :log-directory    #env FLUREE_RAFT_LOG_DIRECTORY
+               :ledger-directory #env FLUREE_RAFT_LEDGER_DIRECTORY
+               :conn             #ig/ref :fluree/connection
+               :watcher          #ig/ref :fluree/watcher
+               :subscriptions    #ig/ref :fluree/subscriptions}}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -28,9 +28,11 @@
 
  :fluree/subscriptions {}
 
- :fluree/standalone {:conn          #ig/ref :fluree/connection
-                     :watcher       #ig/ref :fluree/watcher
-                     :subscriptions #ig/ref :fluree/subscriptions}
+ :fluree/standalone {:conn            #ig/ref :fluree/connection
+                     :watcher         #ig/ref :fluree/watcher
+                     :subscriptions   #ig/ref :fluree/subscriptions
+                     :max-pending-txs #or [#env FLUREE_STANDALONE_MAX_PENDING_TXS
+                                           16]}
 
  :fluree/handler {:conn          #ig/ref :fluree/connection
                   :consensus     #ig/ref :fluree/consensus

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -32,28 +32,6 @@
                      :watcher       #ig/ref :fluree/watcher
                      :subscriptions #ig/ref :fluree/subscriptions}}
 
- :fluree/raft {:log-history      #or [#env FLUREE_RAFT_LOG_HISTORY
-                                      10]
-               :entries-max      #or [#env FLUREE_RAFT_ENTRIES_MAX
-                                      50]
-               :catch-up-rounds  #or [#env FLUREE_RAFT_CATCH_UP_ROUNDS
-                                      10]
-               :storage-type     #or [#keyword #env FLUREE_RAFT_STORAGE_TYPE
-                                      :file]
-               :servers          #or [#env FLUREE_RAFT_SERVERS
-                                      #profile {:dev    "/ip4/127.0.0.1/tcp/62071"
-                                                :prod   nil
-                                                :docker "/ip4/127.0.0.1/tcp/62071"}]
-               :this-server      #or [#env FLUREE_RAFT_THIS_SERVER
-                                      #profile {:dev    "/ip4/127.0.0.1/tcp/62071"
-                                                :prod   nil
-                                                :docker "/ip4/127.0.0.1/tcp/62071"}]
-               :log-directory    #env FLUREE_RAFT_LOG_DIRECTORY
-               :ledger-directory #env FLUREE_RAFT_LEDGER_DIRECTORY
-               :conn             #ig/ref :fluree/connection
-               :watcher          #ig/ref :fluree/watcher
-               :subscriptions    #ig/ref :fluree/subscriptions}
-
  :fluree/handler {:conn          #ig/ref :fluree/connection
                   :consensus     #ig/ref :fluree/consensus
                   :watcher       #ig/ref :fluree/watcher

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -28,11 +28,7 @@
 
  :fluree/subscriptions {}
 
- :fluree/standalone {:address       #or [#env FLUREE_STANDALONE_ADDRESS
-                                         #profile {:dev    "/ip4/127.0.0.1/tcp/62071"
-                                                   :prod   nil
-                                                   :docker "/ip4/127.0.0.1/tcp/62071"}]
-                     :conn          #ig/ref :fluree/connection
+ :fluree/standalone {:conn          #ig/ref :fluree/connection
                      :watcher       #ig/ref :fluree/watcher
                      :subscriptions #ig/ref :fluree/subscriptions}}
 

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -30,7 +30,7 @@
 
  :fluree/standalone {:conn          #ig/ref :fluree/connection
                      :watcher       #ig/ref :fluree/watcher
-                     :subscriptions #ig/ref :fluree/subscriptions}}
+                     :subscriptions #ig/ref :fluree/subscriptions}
 
  :fluree/handler {:conn          #ig/ref :fluree/connection
                   :consensus     #ig/ref :fluree/consensus

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -21,7 +21,7 @@
                      :defaults       {:indexer {:reindex-min-bytes 1000
                                                 :reindex-max-bytes 10000000}}}
 
- :fluree/watcher {:max-tx-wait-ms #or [#env FLUREE_HTTP_MAX_TX_WAIT_MS
+ :fluree/watcher {:max-tx-wait-ms #or [#env FLUREE_MAX_TX_WAIT_MS
                                        #profile {:dev    45000
                                                  :prod   45000
                                                  :docker 45000}]}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -28,10 +28,14 @@
 
  :fluree/subscriptions {}
 
- :fluree/standalone {:address #or [#env FLUREE_STANDALONE_ADDRESS
-                                   #profile {:dev    "/ip4/127.0.0.1/tcp/62071"
-                                             :prod   nil
-                                             :docker "/ip4/127.0.0.1/tcp/62071"}]}}
+ :fluree/standalone {:address       #or [#env FLUREE_STANDALONE_ADDRESS
+                                         #profile {:dev    "/ip4/127.0.0.1/tcp/62071"
+                                                   :prod   nil
+                                                   :docker "/ip4/127.0.0.1/tcp/62071"}]
+                     :conn          #ig/ref :fluree/connection
+                     :watcher       #ig/ref :fluree/watcher
+                     :subscriptions #ig/ref :fluree/subscriptions}}
+
  :fluree/raft {:log-history      #or [#env FLUREE_RAFT_LOG_HISTORY
                                       10]
                :entries-max      #or [#env FLUREE_RAFT_ENTRIES_MAX

--- a/src/fluree/server/consensus.clj
+++ b/src/fluree/server/consensus.clj
@@ -1,10 +1,38 @@
 (ns fluree.server.consensus
   "To allow for pluggable consensus, we have a TxGroup protocol. In order to allow
   for a new consensus type, we need to create a record with all of the following
-  methods. Currently, we support Raft and Solo.")
+  methods. Currently, we support Raft and Standalone."
+  (:require [fluree.db.util.log :as log]
+            [fluree.server.subscriptions :as subscriptions]
+            [fluree.server.watcher :as watcher]))
 
 (set! *warn-on-reflection* true)
 
 (defprotocol TxGroup
   (queue-new-ledger [group ledger-id tx-id txn opts])
   (queue-new-transaction [group ledger-id tx-id txn opts]))
+
+(defn broadcast-new-ledger!
+  [subscriptions watcher new-ledger-result]
+  (let [{:keys [ledger-id server tx-id commit-file-meta]} new-ledger-result]
+    (log/info (str "New Ledger successfully created by server " server
+                   ": " ledger-id " with tx-id: " tx-id "."))
+    (watcher/deliver-watch watcher tx-id new-ledger-result)
+    (subscriptions/send-message-to-all subscriptions "ledger-created" ledger-id (:json commit-file-meta))
+    :success))
+
+(defn broadcast-new-commit!
+  [subscriptions watcher commit-result]
+  (let [{:keys [ledger-id tx-id server commit-file-meta]} commit-result]
+    (log/info "New transaction completed for" ledger-id
+              "tx-id: " tx-id "by server:" server)
+    (watcher/deliver-watch watcher tx-id commit-result)
+    (subscriptions/send-message-to-all subscriptions "new-commit" ledger-id
+                                       (:json commit-file-meta))
+    :success))
+
+(defn broadcast-error!
+  [watcher error-meta]
+  (let [{:keys [tx-id ex-message ex-data]} error-meta]
+    (log/debug "Delivering tx-exception to watcher with msg/data: " ex-message ex-data)
+    (watcher/deliver-watch watcher tx-id (ex-info ex-message ex-data))))

--- a/src/fluree/server/consensus.clj
+++ b/src/fluree/server/consensus.clj
@@ -16,13 +16,13 @@
 (defn queue-new-ledger
   [group ledger-id tx-id txn opts]
   (log/trace "queue-new-ledger:" ledger-id tx-id txn)
-  (let [ledger-msg (messages/queue-new-ledger ledger-id tx-id txn opts)]
+  (let [ledger-msg (messages/create-ledger ledger-id tx-id txn opts)]
     (-queue-new-ledger group ledger-msg)))
 
 (defn queue-new-transaction
   [group ledger-id tx-id txn opts]
   (log/trace "queue-new-transaction:" txn)
-  (let [txn-msg (messages/queue-new-transaction ledger-id tx-id txn opts)]
+  (let [txn-msg (messages/commit-transaction ledger-id tx-id txn opts)]
     (-queue-new-transaction group txn-msg)))
 
 (defn broadcast-new-ledger!

--- a/src/fluree/server/consensus.clj
+++ b/src/fluree/server/consensus.clj
@@ -1,5 +1,5 @@
 (ns fluree.server.consensus
-  "To allow for pluggable consensus, we have a TxGroup protocol. In order to allow
+  "To allow for pluggable consensus, we have a Transactor protocol. In order to allow
   for a new consensus type, we need to create a record with all of the following
   methods. Currently, we support Raft and Standalone."
   (:require [fluree.db.util.log :as log]
@@ -7,7 +7,7 @@
 
 (set! *warn-on-reflection* true)
 
-(defprotocol TxGroup
+(defprotocol Transactor
   (-queue-new-ledger [group event-params])
   (-queue-new-transaction [group event-params]))
 

--- a/src/fluree/server/consensus.clj
+++ b/src/fluree/server/consensus.clj
@@ -3,49 +3,49 @@
   for a new consensus type, we need to create a record with all of the following
   methods. Currently, we support Raft and Standalone."
   (:require [fluree.db.util.log :as log]
-            [fluree.server.consensus.messages :as messages]
+            [fluree.server.consensus.events :as events]
             [fluree.server.subscriptions :as subscriptions]
             [fluree.server.watcher :as watcher]))
 
 (set! *warn-on-reflection* true)
 
 (defprotocol TxGroup
-  (-queue-new-ledger [group ledger-msg])
-  (-queue-new-transaction [group txn-msg]))
+  (-queue-new-ledger [group event-params])
+  (-queue-new-transaction [group event-params]))
 
 (defn queue-new-ledger
   [group ledger-id tx-id txn opts]
   (log/trace "queue-new-ledger:" ledger-id tx-id txn)
-  (let [ledger-msg (messages/create-ledger ledger-id tx-id txn opts)]
-    (-queue-new-ledger group ledger-msg)))
+  (let [event-params (events/create-ledger ledger-id tx-id txn opts)]
+    (-queue-new-ledger group event-params)))
 
 (defn queue-new-transaction
   [group ledger-id tx-id txn opts]
   (log/trace "queue-new-transaction:" txn)
-  (let [txn-msg (messages/commit-transaction ledger-id tx-id txn opts)]
-    (-queue-new-transaction group txn-msg)))
+  (let [event-params (events/commit-transaction ledger-id tx-id txn opts)]
+    (-queue-new-transaction group event-params)))
 
 (defn broadcast-new-ledger!
-  [subscriptions watcher new-ledger-result]
-  (let [{:keys [ledger-id server tx-id commit-file-meta]} new-ledger-result]
+  [subscriptions watcher ledger-created-event]
+  (let [{:keys [ledger-id server tx-id commit-file-meta]} ledger-created-event]
     (log/info (str "New Ledger successfully created by server " server
                    ": " ledger-id " with tx-id: " tx-id "."))
-    (watcher/deliver-watch watcher tx-id new-ledger-result)
+    (watcher/deliver-watch watcher tx-id ledger-created-event)
     (subscriptions/send-message-to-all subscriptions "ledger-created" ledger-id (:json commit-file-meta))
     :success))
 
 (defn broadcast-new-commit!
-  [subscriptions watcher commit-result]
-  (let [{:keys [ledger-id tx-id server commit-file-meta]} commit-result]
+  [subscriptions watcher transaction-commited-event]
+  (let [{:keys [ledger-id tx-id server commit-file-meta]} transaction-commited-event]
     (log/info "New transaction completed for" ledger-id
               "tx-id: " tx-id "by server:" server)
-    (watcher/deliver-watch watcher tx-id commit-result)
+    (watcher/deliver-watch watcher tx-id transaction-commited-event)
     (subscriptions/send-message-to-all subscriptions "new-commit" ledger-id
                                        (:json commit-file-meta))
     :success))
 
 (defn broadcast-error!
-  [watcher error-meta]
-  (let [{:keys [tx-id ex-message ex-data]} error-meta]
+  [watcher error-event]
+  (let [{:keys [tx-id ex-message ex-data]} error-event]
     (log/debug "Delivering tx-exception to watcher with msg/data: " ex-message ex-data)
     (watcher/deliver-watch watcher tx-id (ex-info ex-message ex-data))))

--- a/src/fluree/server/consensus.clj
+++ b/src/fluree/server/consensus.clj
@@ -3,9 +3,7 @@
   for a new consensus type, we need to create a record with all of the following
   methods. Currently, we support Raft and Standalone."
   (:require [fluree.db.util.log :as log]
-            [fluree.server.consensus.events :as events]
-            [fluree.server.subscriptions :as subscriptions]
-            [fluree.server.watcher :as watcher]))
+            [fluree.server.consensus.events :as events]))
 
 (set! *warn-on-reflection* true)
 
@@ -24,28 +22,3 @@
   (log/trace "queue-new-transaction:" txn)
   (let [event-params (events/commit-transaction ledger-id tx-id txn opts)]
     (-queue-new-transaction group event-params)))
-
-(defn broadcast-new-ledger!
-  [subscriptions watcher ledger-created-event]
-  (let [{:keys [ledger-id server tx-id commit-file-meta]} ledger-created-event]
-    (log/info (str "New Ledger successfully created by server " server
-                   ": " ledger-id " with tx-id: " tx-id "."))
-    (watcher/deliver-watch watcher tx-id ledger-created-event)
-    (subscriptions/send-message-to-all subscriptions "ledger-created" ledger-id (:json commit-file-meta))
-    :success))
-
-(defn broadcast-new-commit!
-  [subscriptions watcher transaction-commited-event]
-  (let [{:keys [ledger-id tx-id server commit-file-meta]} transaction-commited-event]
-    (log/info "New transaction completed for" ledger-id
-              "tx-id: " tx-id "by server:" server)
-    (watcher/deliver-watch watcher tx-id transaction-commited-event)
-    (subscriptions/send-message-to-all subscriptions "new-commit" ledger-id
-                                       (:json commit-file-meta))
-    :success))
-
-(defn broadcast-error!
-  [watcher error-event]
-  (let [{:keys [tx-id ex-message ex-data]} error-event]
-    (log/debug "Delivering tx-exception to watcher with msg/data: " ex-message ex-data)
-    (watcher/deliver-watch watcher tx-id (ex-info ex-message ex-data))))

--- a/src/fluree/server/consensus/broadcast.clj
+++ b/src/fluree/server/consensus/broadcast.clj
@@ -1,0 +1,31 @@
+(ns fluree.server.consensus.broadcast
+  (:require [fluree.db.util.log :as log]
+            [fluree.server.subscriptions :as subscriptions]
+            [fluree.server.watcher :as watcher]))
+
+(set! *warn-on-reflection* true)
+
+(defn announce-new-ledger!
+  [subscriptions watcher ledger-created-event]
+  (let [{:keys [ledger-id server tx-id commit-file-meta]} ledger-created-event]
+    (log/info (str "New Ledger successfully created by server " server
+                   ": " ledger-id " with tx-id: " tx-id "."))
+    (watcher/deliver-watch watcher tx-id ledger-created-event)
+    (subscriptions/send-message-to-all subscriptions "ledger-created" ledger-id (:json commit-file-meta))
+    :success))
+
+(defn announce-new-commit!
+  [subscriptions watcher transaction-commited-event]
+  (let [{:keys [ledger-id tx-id server commit-file-meta]} transaction-commited-event]
+    (log/info "New transaction completed for" ledger-id
+              "tx-id: " tx-id "by server:" server)
+    (watcher/deliver-watch watcher tx-id transaction-commited-event)
+    (subscriptions/send-message-to-all subscriptions "new-commit" ledger-id
+                                       (:json commit-file-meta))
+    :success))
+
+(defn announce-error!
+  [watcher error-event]
+  (let [{:keys [tx-id ex-message ex-data]} error-event]
+    (log/debug "Delivering tx-exception to watcher with msg/data: " ex-message ex-data)
+    (watcher/deliver-watch watcher tx-id (ex-info ex-message ex-data))))

--- a/src/fluree/server/consensus/broadcast.clj
+++ b/src/fluree/server/consensus/broadcast.clj
@@ -1,7 +1,7 @@
 (ns fluree.server.consensus.broadcast
   (:require [fluree.db.util.log :as log]
-            [fluree.server.subscriptions :as subscriptions]
-            [fluree.server.watcher :as watcher]))
+            [fluree.server.consensus.subscriptions :as subscriptions]
+            [fluree.server.consensus.watcher :as watcher]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/fluree/server/consensus/events.clj
+++ b/src/fluree/server/consensus/events.clj
@@ -1,5 +1,5 @@
-(ns fluree.server.consensus.messages
-  "Common namespace for defining consensus messages shared across consensus
+(ns fluree.server.consensus.events
+  "Common namespace for defining consensus event messages shared across consensus
   protocols")
 
 (defn create-ledger
@@ -14,18 +14,6 @@
                    :ledger-id ledger-id
                    :opts      opts
                    :instant   (System/currentTimeMillis)}])
-
-(defn ledger-created
-  ([{:keys [ledger-id tx-id] :as _event-params}
-    commit-result]
-   (-> commit-result
-       (select-keys [:db :data-file-meta :commit-file-meta])
-       (assoc :tx-id tx-id
-              :ledger-id ledger-id
-              :t 1)))
-  ([processing-server event-params commit-result]
-   (-> (ledger-created event-params commit-result)
-       (assoc :server processing-server))))
 
 (defn commit-transaction
   "Upon receiving a request to create a new ledger, an event

--- a/src/fluree/server/consensus/messages.clj
+++ b/src/fluree/server/consensus/messages.clj
@@ -2,21 +2,6 @@
   "Common namespace for defining consensus messages shared across consensus
   protocols")
 
-
-(defn new-commit
-  "Post-transaction, the message we will broadcast out and/or deliver
-  to a client awaiting a response."
-  [processing-server
-   {:keys [ledger-id tx-id] :as _event-params}
-   {:keys [db data-file-meta commit-file-meta] :as _commit-result}]
-  {:ledger-id        ledger-id
-   :data-file-meta   data-file-meta
-   :commit-file-meta commit-file-meta
-   ;; below is metadata for quickly validating into the state machine, not retained
-   :t                (:t db) ;; for quickly validating this is the next 'block'
-   :tx-id            tx-id ;; for quickly removing from the queue
-   :server           processing-server})
-
 (defn queue-new-ledger
   "Upon receiving a request to create a new ledger, an event
   message must be queued into the consensus state machine.
@@ -30,6 +15,18 @@
                    :opts      opts
                    :instant   (System/currentTimeMillis)}])
 
+(defn new-ledger
+  ([{:keys [ledger-id tx-id] :as _event-params}
+    commit-result]
+   (-> commit-result
+       (select-keys [:db :data-file-meta :commit-file-meta])
+       (assoc :tx-id tx-id
+              :ledger-id ledger-id
+              :t 1)))
+  ([processing-server event-params commit-result]
+   (-> (new-ledger event-params commit-result)
+       (assoc :server processing-server))))
+
 (defn queue-new-transaction
   "Upon receiving a request to create a new ledger, an event
   message must be queued into the consensus state machine.
@@ -42,3 +39,29 @@
               :ledger-id ledger-id
               :opts      opts
               :instant   (System/currentTimeMillis)}])
+
+(defn new-commit
+  "Post-transaction, the message we will broadcast out and/or deliver
+  to a client awaiting a response."
+  ([{:keys [ledger-id tx-id] :as _event-params}
+    {:keys [db data-file-meta commit-file-meta] :as _commit-result}]
+   {:ledger-id        ledger-id
+    :data-file-meta   data-file-meta
+    :commit-file-meta commit-file-meta
+    ;; below is metadata for quickly validating into the state machine, not retained
+    :t                (:t db) ;; for quickly validating this is the next 'block'
+    :tx-id            tx-id ;; for quickly removing from the queue
+    })
+  ([processing-server event-params commit-result]
+   (-> (new-commit event-params commit-result)
+       (assoc :server processing-server))))
+
+(defn error
+  ([params exception]
+   (-> params
+       (select-keys [:ledger-id :tx-id])
+       (assoc :ex-message (ex-message exception)
+              :ex-data    (ex-data exception))))
+  ([processing-server params exception]
+   (-> (error params exception)
+       (assoc :server processing-server))))

--- a/src/fluree/server/consensus/messages.clj
+++ b/src/fluree/server/consensus/messages.clj
@@ -1,4 +1,4 @@
-(ns fluree.server.consensus.msg-format
+(ns fluree.server.consensus.messages
   "Common namespace for defining consensus messages shared across consensus
   protocols")
 
@@ -16,9 +16,6 @@
    :t                (:t db) ;; for quickly validating this is the next 'block'
    :tx-id            tx-id ;; for quickly removing from the queue
    :server           processing-server})
-
-(defn error
-  [])
 
 (defn queue-new-ledger
   "Upon receiving a request to create a new ledger, an event

--- a/src/fluree/server/consensus/messages.clj
+++ b/src/fluree/server/consensus/messages.clj
@@ -2,7 +2,7 @@
   "Common namespace for defining consensus messages shared across consensus
   protocols")
 
-(defn queue-new-ledger
+(defn create-ledger
   "Upon receiving a request to create a new ledger, an event
   message must be queued into the consensus state machine.
 
@@ -15,7 +15,7 @@
                    :opts      opts
                    :instant   (System/currentTimeMillis)}])
 
-(defn new-ledger
+(defn ledger-created
   ([{:keys [ledger-id tx-id] :as _event-params}
     commit-result]
    (-> commit-result
@@ -24,10 +24,10 @@
               :ledger-id ledger-id
               :t 1)))
   ([processing-server event-params commit-result]
-   (-> (new-ledger event-params commit-result)
+   (-> (ledger-created event-params commit-result)
        (assoc :server processing-server))))
 
-(defn queue-new-transaction
+(defn commit-transaction
   "Upon receiving a request to create a new ledger, an event
   message must be queued into the consensus state machine.
 
@@ -40,7 +40,7 @@
               :opts      opts
               :instant   (System/currentTimeMillis)}])
 
-(defn new-commit
+(defn transaction-committed
   "Post-transaction, the message we will broadcast out and/or deliver
   to a client awaiting a response."
   ([{:keys [ledger-id tx-id] :as _event-params}
@@ -53,7 +53,7 @@
     :tx-id            tx-id ;; for quickly removing from the queue
     })
   ([processing-server event-params commit-result]
-   (-> (new-commit event-params commit-result)
+   (-> (transaction-committed event-params commit-result)
        (assoc :server processing-server))))
 
 (defn error

--- a/src/fluree/server/consensus/msg_format.clj
+++ b/src/fluree/server/consensus/msg_format.clj
@@ -1,7 +1,7 @@
-(ns fluree.server.consensus.msg-format)
+(ns fluree.server.consensus.msg-format
+  "Common namespace for defining consensus messages shared across consensus
+  protocols")
 
-;; to the extent messages through consensus can be shared across
-;; consensus protocols, this provies a common place to define them
 
 (defn new-commit
   "Post-transaction, the message we will broadcast out and/or deliver
@@ -16,6 +16,9 @@
    :t                (:t db) ;; for quickly validating this is the next 'block'
    :tx-id            tx-id ;; for quickly removing from the queue
    :server           processing-server})
+
+(defn error
+  [])
 
 (defn queue-new-ledger
   "Upon receiving a request to create a new ledger, an event

--- a/src/fluree/server/consensus/raft.clj
+++ b/src/fluree/server/consensus/raft.clj
@@ -324,7 +324,7 @@
 
 (defrecord RaftGroup [state-atom event-chan command-chan this-server port
                       close raft raft-initialized open-api private-keys]
-  consensus/TxGroup
+  consensus/Transactor
   (-queue-new-ledger [group ledger-msg]
     (new-entry-async group ledger-msg))
   (-queue-new-transaction [group txn-msg]

--- a/src/fluree/server/consensus/raft.clj
+++ b/src/fluree/server/consensus/raft.clj
@@ -323,31 +323,13 @@
                  ;; send command to leader
                  (send-rpc raft leader :new-command command-data nil)))))))
 
-(defn queue-new-ledger-raft
-  "Queues a new ledger into the consensus layer for processing.
-  Returns a core async channel that will eventually contain true if successful."
-  [group ledger-id tx-id txn opts]
-  (log/debug "Consensus - queue new ledger:" ledger-id tx-id txn)
-  (new-entry-async
-   group
-   (messages/queue-new-ledger ledger-id tx-id txn opts)))
-
-(defn queue-new-transaction-raft
-  "Queues a new transaction into the consensus layer for processing.
-  Returns a core async channel that will eventually contain a truthy value if successful."
-  [group ledger-id tx-id txn opts]
-  (log/trace "queue-new-transaction txn:" txn)
-  (new-entry-async
-   group
-   (messages/queue-new-transaction ledger-id tx-id txn opts)))
-
 (defrecord RaftGroup [state-atom event-chan command-chan this-server port
                       close raft raft-initialized open-api private-keys]
   consensus/TxGroup
-  (queue-new-ledger [group ledger-id tx-id txn opts]
-    (queue-new-ledger-raft group ledger-id tx-id txn opts))
-  (queue-new-transaction [group ledger-id tx-id txn opts]
-    (queue-new-transaction-raft group ledger-id tx-id txn opts)))
+  (-queue-new-ledger [group ledger-msg]
+    (new-entry-async group ledger-msg))
+  (-queue-new-transaction [group txn-msg]
+    (new-entry-async group txn-msg)))
 
 (defn leader-change-fn
   "Function called every time there is a leader change to provide any extra

--- a/src/fluree/server/consensus/raft.clj
+++ b/src/fluree/server/consensus/raft.clj
@@ -6,7 +6,6 @@
             [fluree.db.util.log :as log]
             [fluree.raft :as raft]
             [fluree.server.consensus :as consensus]
-            [fluree.server.consensus.messages :as messages]
             [fluree.server.consensus.network.multi-addr :as multi-addr]
             [fluree.server.consensus.network.tcp :as ftcp]
             [fluree.server.consensus.raft.handler :as raft-handler]

--- a/src/fluree/server/consensus/raft.clj
+++ b/src/fluree/server/consensus/raft.clj
@@ -6,7 +6,7 @@
             [fluree.db.util.log :as log]
             [fluree.raft :as raft]
             [fluree.server.consensus :as consensus]
-            [fluree.server.consensus.msg-format :as msg-format]
+            [fluree.server.consensus.messages :as messages]
             [fluree.server.consensus.network.multi-addr :as multi-addr]
             [fluree.server.consensus.network.tcp :as ftcp]
             [fluree.server.consensus.raft.handler :as raft-handler]
@@ -330,7 +330,7 @@
   (log/debug "Consensus - queue new ledger:" ledger-id tx-id txn)
   (new-entry-async
    group
-   (msg-format/queue-new-ledger ledger-id tx-id txn opts)))
+   (messages/queue-new-ledger ledger-id tx-id txn opts)))
 
 (defn queue-new-transaction-raft
   "Queues a new transaction into the consensus layer for processing.
@@ -339,7 +339,7 @@
   (log/trace "queue-new-transaction txn:" txn)
   (new-entry-async
    group
-   (msg-format/queue-new-transaction ledger-id tx-id txn opts)))
+   (messages/queue-new-transaction ledger-id tx-id txn opts)))
 
 (defrecord RaftGroup [state-atom event-chan command-chan this-server port
                       close raft raft-initialized open-api private-keys]

--- a/src/fluree/server/consensus/raft/handlers/create_ledger.clj
+++ b/src/fluree/server/consensus/raft/handlers/create_ledger.clj
@@ -57,7 +57,7 @@
 
   Returns promise that will have the eventual response once committed."
   [{:keys [consensus/raft-state] :as config} params commit-result]
-  (let [created-body (messages/new-commit ;; same as new-commit message
+  (let [created-body (messages/transaction-committed ; same as new-commit message
                       (participant/this-server raft-state)
                       params commit-result)]
 

--- a/src/fluree/server/consensus/raft/handlers/create_ledger.clj
+++ b/src/fluree/server/consensus/raft/handlers/create_ledger.clj
@@ -3,7 +3,7 @@
             [fluree.db.constants :as const]
             [fluree.db.util.log :as log]
             [fluree.raft.leader :refer [is-leader?]]
-            [fluree.server.consensus.msg-format :as msg-format]
+            [fluree.server.consensus.messages :as messages]
             [fluree.server.consensus.raft.participant :as participant]
             [fluree.server.consensus.raft.producers.new-index-file :as new-index-file]
             [fluree.server.handlers.shared :refer [deref!]]))
@@ -57,7 +57,7 @@
 
   Returns promise that will have the eventual response once committed."
   [{:keys [consensus/raft-state] :as config} params commit-result]
-  (let [created-body (msg-format/new-commit ;; same as new-commit message
+  (let [created-body (messages/new-commit ;; same as new-commit message
                       (participant/this-server raft-state)
                       params commit-result)]
 

--- a/src/fluree/server/consensus/raft/handlers/create_ledger.clj
+++ b/src/fluree/server/consensus/raft/handlers/create_ledger.clj
@@ -3,7 +3,7 @@
             [fluree.db.constants :as const]
             [fluree.db.util.log :as log]
             [fluree.raft.leader :refer [is-leader?]]
-            [fluree.server.consensus.messages :as messages]
+            [fluree.server.consensus.events :as events]
             [fluree.server.consensus.raft.participant :as participant]
             [fluree.server.consensus.raft.producers.new-index-file :as new-index-file]
             [fluree.server.handlers.shared :refer [deref!]]))
@@ -57,7 +57,7 @@
 
   Returns promise that will have the eventual response once committed."
   [{:keys [consensus/raft-state] :as config} params commit-result]
-  (let [created-body (messages/transaction-committed ; same as new-commit message
+  (let [created-body (events/transaction-committed ; same as new-commit message
                       (participant/this-server raft-state)
                       params commit-result)]
 

--- a/src/fluree/server/consensus/raft/handlers/ledger_created.clj
+++ b/src/fluree/server/consensus/raft/handlers/ledger_created.clj
@@ -3,7 +3,7 @@
             [clojure.java.io :as io]
             [fluree.db.util.filesystem :as fs]
             [fluree.db.util.log :as log]
-            [fluree.server.consensus :as consensus]
+            [fluree.server.consensus.broadcast :as broadcast]
             [fluree.server.consensus.raft.handlers.new-commit :as new-commit])
   (:import (java.io File)))
 
@@ -84,4 +84,4 @@
 (defn broadcast!
   "Responsible for producing the event broadcast to connected peers."
   [{:keys [fluree/watcher fluree/subscriptions] :as _config} handler-result]
-  (consensus/broadcast-new-ledger! subscriptions watcher handler-result))
+  (broadcast/announce-new-ledger! subscriptions watcher handler-result))

--- a/src/fluree/server/consensus/raft/handlers/ledger_created.clj
+++ b/src/fluree/server/consensus/raft/handlers/ledger_created.clj
@@ -3,9 +3,8 @@
             [clojure.java.io :as io]
             [fluree.db.util.filesystem :as fs]
             [fluree.db.util.log :as log]
-            [fluree.server.consensus.raft.handlers.new-commit :as new-commit]
-            [fluree.server.subscriptions :as subscriptions]
-            [fluree.server.watcher :as watcher])
+            [fluree.server.consensus :as consensus]
+            [fluree.server.consensus.raft.handlers.new-commit :as new-commit])
   (:import (java.io File)))
 
 (set! *warn-on-reflection* true)
@@ -47,12 +46,6 @@
                   :error  :db/unexpected-error}
                  e)))))
 
-(defn return-success-response
-  [watcher {:keys [ledger-id server tx-id] :as params} state-map]
-  (log/info (str "New Ledger successfully created by server " server ": " ledger-id " with tx-id: " tx-id "."))
-  (watcher/deliver-watch watcher tx-id params)
-  (get-in state-map [:ledgers ledger-id]))
-
 (defn clean-up-files
   [{:keys [fluree/conn] :as _config} {:keys [ledger-id] :as _params}]
   (let [local-path (fs/local-path (:storage-path conn))
@@ -90,9 +83,5 @@
 
 (defn broadcast!
   "Responsible for producing the event broadcast to connected peers."
-  [{:keys [fluree/watcher fluree/subscriptions] :as _config}
-   {:keys [ledger-id server tx-id commit-file-meta] :as handler-result}]
-  (log/info (str "New Ledger successfully created by server " server ": " ledger-id " with tx-id: " tx-id "."))
-  (watcher/deliver-watch watcher tx-id handler-result)
-  (subscriptions/send-message-to-all subscriptions "ledger-created" ledger-id (:json commit-file-meta))
-  :success) ;; result of this function is not used
+  [{:keys [fluree/watcher fluree/subscriptions] :as _config} handler-result]
+  (consensus/broadcast-new-ledger! subscriptions watcher handler-result))

--- a/src/fluree/server/consensus/raft/handlers/new_commit.clj
+++ b/src/fluree/server/consensus/raft/handlers/new_commit.clj
@@ -4,7 +4,7 @@
             [fluree.db.storage :as storage]
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.util.log :as log]
-            [fluree.server.consensus :as consensus]))
+            [fluree.server.consensus.broadcast :as broadcast]))
 
 (set! *warn-on-reflection* true)
 
@@ -85,4 +85,4 @@
 (defn broadcast!
   "Responsible for producing the event broadcast to connected peers."
   [{:keys [fluree/watcher fluree/subscriptions] :as _config} commit-result]
-  (consensus/broadcast-new-commit! subscriptions watcher commit-result))
+  (broadcast/announce-new-commit! subscriptions watcher commit-result))

--- a/src/fluree/server/consensus/raft/handlers/new_commit.clj
+++ b/src/fluree/server/consensus/raft/handlers/new_commit.clj
@@ -4,8 +4,7 @@
             [fluree.db.storage :as storage]
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.util.log :as log]
-            [fluree.server.subscriptions :as subscriptions]
-            [fluree.server.watcher :as watcher]))
+            [fluree.server.consensus :as consensus]))
 
 (set! *warn-on-reflection* true)
 
@@ -85,9 +84,5 @@
 
 (defn broadcast!
   "Responsible for producing the event broadcast to connected peers."
-  [{:keys [fluree/watcher fluree/subscriptions] :as _config}
-   {:keys [ledger-id tx-id server commit-file-meta] :as commit-result}]
-  (log/info "New transaction completed for" ledger-id "tx-id: " tx-id "by server:" server)
-  (watcher/deliver-watch watcher tx-id commit-result)
-  (subscriptions/send-message-to-all subscriptions "new-commit" ledger-id (:json commit-file-meta))
-  :success) ;; result of this function is not used
+  [{:keys [fluree/watcher fluree/subscriptions] :as _config} commit-result]
+  (consensus/broadcast-new-commit! subscriptions watcher commit-result))

--- a/src/fluree/server/consensus/raft/handlers/tx_exception.clj
+++ b/src/fluree/server/consensus/raft/handlers/tx_exception.clj
@@ -1,6 +1,6 @@
 (ns fluree.server.consensus.raft.handlers.tx-exception
   (:require [fluree.db.util.log :as log]
-            [fluree.server.consensus :as consensus]))
+            [fluree.server.consensus.broadcast :as broadcast]))
 
 (defn update-ledger-state
   "Updates the latest commit in the ledger, and removes the processed transaction in the queue"
@@ -28,7 +28,7 @@
 
 (defn broadcast!
   [{:keys [fluree/watcher] :as _config} exception-meta]
-  (consensus/broadcast-error! watcher exception-meta))
+  (broadcast/announce-error! watcher exception-meta))
 
 (defn handler
   "Handles transaction exceptions and broadcasts them to network."

--- a/src/fluree/server/consensus/raft/handlers/tx_exception.clj
+++ b/src/fluree/server/consensus/raft/handlers/tx_exception.clj
@@ -1,6 +1,6 @@
 (ns fluree.server.consensus.raft.handlers.tx-exception
   (:require [fluree.db.util.log :as log]
-            [fluree.server.watcher :as watcher]))
+            [fluree.server.consensus :as consensus]))
 
 (defn update-ledger-state
   "Updates the latest commit in the ledger, and removes the processed transaction in the queue"
@@ -27,10 +27,8 @@
                  e)))))
 
 (defn broadcast!
-  [{:keys [fluree/watcher] :as _config}
-   {:keys [tx-id ex-message ex-data] :as _exception-meta}]
-  (log/debug "Delivering tx-exception to watcher with msg/data: " ex-message ex-data)
-  (watcher/deliver-watch watcher tx-id (ex-info ex-message ex-data)))
+  [{:keys [fluree/watcher] :as _config} exception-meta]
+  (consensus/broadcast-error! watcher exception-meta))
 
 (defn handler
   "Handles transaction exceptions and broadcasts them to network."

--- a/src/fluree/server/consensus/raft/producers/new_commit.clj
+++ b/src/fluree/server/consensus/raft/producers/new_commit.clj
@@ -1,5 +1,5 @@
 (ns fluree.server.consensus.raft.producers.new-commit
-  (:require [fluree.server.consensus.messages :as messages]
+  (:require [fluree.server.consensus.events :as events]
             [fluree.server.consensus.raft.participant :as participant]))
 
 (set! *warn-on-reflection* true)
@@ -11,7 +11,7 @@
 
   Returns promise that will have the eventual response once committed."
   [{:keys [consensus/raft-state] :as config} params commit-result]
-  (let [created-body (messages/transaction-committed
+  (let [created-body (events/transaction-committed
                       (participant/this-server raft-state)
                       params commit-result)]
 

--- a/src/fluree/server/consensus/raft/producers/new_commit.clj
+++ b/src/fluree/server/consensus/raft/producers/new_commit.clj
@@ -11,7 +11,7 @@
 
   Returns promise that will have the eventual response once committed."
   [{:keys [consensus/raft-state] :as config} params commit-result]
-  (let [created-body (messages/new-commit
+  (let [created-body (messages/transaction-committed
                       (participant/this-server raft-state)
                       params commit-result)]
 

--- a/src/fluree/server/consensus/raft/producers/new_commit.clj
+++ b/src/fluree/server/consensus/raft/producers/new_commit.clj
@@ -1,5 +1,5 @@
 (ns fluree.server.consensus.raft.producers.new-commit
-  (:require [fluree.server.consensus.msg-format :as msg-format]
+  (:require [fluree.server.consensus.messages :as messages]
             [fluree.server.consensus.raft.participant :as participant]))
 
 (set! *warn-on-reflection* true)
@@ -11,7 +11,7 @@
 
   Returns promise that will have the eventual response once committed."
   [{:keys [consensus/raft-state] :as config} params commit-result]
-  (let [created-body (msg-format/new-commit
+  (let [created-body (messages/new-commit
                       (participant/this-server raft-state)
                       params commit-result)]
 

--- a/src/fluree/server/consensus/raft/producers/tx_exception.clj
+++ b/src/fluree/server/consensus/raft/producers/tx_exception.clj
@@ -1,14 +1,10 @@
 (ns fluree.server.consensus.raft.producers.tx-exception
-  (:require [fluree.server.consensus.raft.participant :as participant]))
+  (:require [fluree.server.consensus.messages :as messages]
+            [fluree.server.consensus.raft.participant :as participant]))
 
 (defn consensus-push-tx-exception
-  [{:keys [consensus/raft-state] :as config}
-   {:keys [ledger-id tx-id] :as _params}
-   tx-exception]
-  (let [created-body {:ledger-id  ledger-id
-                      :ex-message (ex-message tx-exception)
-                      :ex-data    (ex-data tx-exception)
-                      :tx-id      tx-id ;; for quickly removing from the queue
-                      :server     (participant/this-server raft-state)}]
+  [{:keys [consensus/raft-state] :as config} params tx-exception]
+  (let [server (participant/this-server raft-state)
+        error-message (messages/error server params tx-exception)]
     ;; returns promise
-    (participant/leader-new-command! config :tx-exception created-body)))
+    (participant/leader-new-command! config :tx-exception error-message)))

--- a/src/fluree/server/consensus/raft/producers/tx_exception.clj
+++ b/src/fluree/server/consensus/raft/producers/tx_exception.clj
@@ -4,7 +4,7 @@
 
 (defn consensus-push-tx-exception
   [{:keys [consensus/raft-state] :as config} params tx-exception]
-  (let [server (participant/this-server raft-state)
-        error-message (messages/error server params tx-exception)]
+  (let [server    (participant/this-server raft-state)
+        error-msg (messages/error server params tx-exception)]
     ;; returns promise
-    (participant/leader-new-command! config :tx-exception error-message)))
+    (participant/leader-new-command! config :tx-exception error-msg)))

--- a/src/fluree/server/consensus/raft/producers/tx_exception.clj
+++ b/src/fluree/server/consensus/raft/producers/tx_exception.clj
@@ -1,10 +1,10 @@
 (ns fluree.server.consensus.raft.producers.tx-exception
-  (:require [fluree.server.consensus.messages :as messages]
+  (:require [fluree.server.consensus.events :as events]
             [fluree.server.consensus.raft.participant :as participant]))
 
 (defn consensus-push-tx-exception
   [{:keys [consensus/raft-state] :as config} params tx-exception]
   (let [server    (participant/this-server raft-state)
-        error-msg (messages/error server params tx-exception)]
+        error-msg (events/error server params tx-exception)]
     ;; returns promise
     (participant/leader-new-command! config :tx-exception error-msg)))

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -6,7 +6,7 @@
             [fluree.db.util.core :refer [get-first-value]]
             [fluree.db.util.log :as log]
             [fluree.server.consensus :as consensus]
-            [fluree.server.consensus.msg-format :as msg-format]
+            [fluree.server.consensus.messages :as messages]
             [fluree.server.handlers.shared :refer [deref!]]
             [fluree.server.subscriptions :as subscriptions]
             [fluree.server.watcher :as watcher]))
@@ -15,12 +15,12 @@
   consensus/TxGroup
   (queue-new-ledger [_ ledger-id tx-id txn opts]
     (go
-      (let [event-msg (msg-format/queue-new-ledger ledger-id tx-id txn opts)]
+      (let [event-msg (messages/queue-new-ledger ledger-id tx-id txn opts)]
         (async/offer! tx-queue event-msg))))
 
   (queue-new-transaction [_ ledger-id tx-id txn opts]
     (go
-      (let [event-msg (msg-format/queue-new-transaction ledger-id tx-id txn opts)]
+      (let [event-msg (messages/queue-new-transaction ledger-id tx-id txn opts)]
         (async/offer! tx-queue event-msg)))))
 
 (defn broadcast-new-ledger!
@@ -80,7 +80,7 @@
                             deref!)
           commit-result (deref!
                          (fluree/commit! ledger staged-db {:file-data? true}))
-          broadcast-msg (msg-format/new-commit nil params commit-result)]
+          broadcast-msg (messages/new-commit nil params commit-result)]
       (broadcast-new-commit! subscriptions watcher broadcast-msg))))
 
 (defn process-event

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -115,7 +115,7 @@
 
             (nil? event)
             (do
-              (log/warn "Closing local transaction queue was closed. No new transactions will be processed.")
+              (log/warn "Local transaction queue was closed. No new transactions will be processed.")
               ::closed)
 
             :else

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -101,7 +101,7 @@
 
 (defn new-tx-queue
   [conn subscriptions watcher]
-  (let [tx-queue (async/chan)]
+  (let [tx-queue (async/chan 512)]
     (go
       (loop [i 0]
         (let [timeout-ch (async/timeout 5000)

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -1,29 +1,29 @@
 (ns fluree.server.consensus.standalone
   (:require [clojure.core.async :as async :refer [<! >! go]]
-            [fluree.db.constants :as const]
             [fluree.db.api :as fluree]
-            [fluree.db.util.core :refer [get-first-value]]
+            [fluree.db.constants :as const]
             [fluree.db.util.async :refer [go-try]]
+            [fluree.db.util.core :refer [get-first-value]]
             [fluree.db.util.log :as log]
-            [fluree.server.subscriptions :as subscriptions]
             [fluree.server.consensus :as consensus]
             [fluree.server.consensus.msg-format :as msg-format]
-            [fluree.server.watcher :as watcher]
-            [fluree.server.handlers.shared :refer [deref!]]))
+            [fluree.server.handlers.shared :refer [deref!]]
+            [fluree.server.subscriptions :as subscriptions]
+            [fluree.server.watcher :as watcher]))
 
 (defrecord StandaloneTransactor [tx-queue]
   consensus/TxGroup
   (queue-new-ledger [_ ledger-id tx-id txn opts]
     (go
       (let [event-msg (msg-format/queue-new-ledger ledger-id tx-id txn opts)]
-      (>! tx-queue event-msg)
-      true)))
+        (>! tx-queue event-msg)
+        true)))
 
   (queue-new-transaction [_ ledger-id tx-id txn opts]
     (go
       (let [event-msg (msg-format/queue-new-transaction ledger-id tx-id txn opts)]
-      (>! tx-queue event-msg)
-      true))))
+        (>! tx-queue event-msg)
+        true))))
 
 (defn broadcast-new-ledger!
   "Responsible for producing the event broadcast to connected peers."
@@ -55,8 +55,8 @@
                          ;; following uses :file-data? and will return map with {:keys [db data-file commit-file]}
                           (fluree/commit! ledger staged-db {:file-data? true}))]
       (broadcast-new-ledger! subscriptions watcher (assoc commmit-result :tx-id tx-id
-                                           :ledger-id ledger-id
-                                           :t 1)))))
+                                                          :ledger-id ledger-id
+                                                          :t 1)))))
 
 (defn broadcast-new-commit!
   "Responsible for producing the event broadcast to connected peers."

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -79,8 +79,8 @@
                    "and of a supported event type. Received:" event e)))))
 
 (defn new-tx-queue
-  [conn subscriptions watcher]
-  (let [tx-queue (async/chan 16)]
+  [conn subscriptions watcher max-pending-txs]
+  (let [tx-queue (async/chan max-pending-txs)]
     (go-loop [i 0]
       (let [timeout-ch (async/timeout 5000)
             [event ch] (async/alts! [tx-queue timeout-ch])]
@@ -104,8 +104,8 @@
     tx-queue))
 
 (defn start
-  [conn subscriptions watcher]
-  (let [tx-queue (new-tx-queue conn subscriptions watcher)]
+  [conn subscriptions watcher max-pending-txs]
+  (let [tx-queue (new-tx-queue conn subscriptions watcher max-pending-txs)]
     (->StandaloneTransactor tx-queue)))
 
 (defn stop

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -11,15 +11,13 @@
 
 (defrecord StandaloneTransactor [tx-queue]
   consensus/TxGroup
-  (queue-new-ledger [_ ledger-id tx-id txn opts]
+  (-queue-new-ledger [_ ledger-msg]
     (go
-      (let [event-msg (messages/queue-new-ledger ledger-id tx-id txn opts)]
-        (async/offer! tx-queue event-msg))))
+      (async/offer! tx-queue ledger-msg)))
 
-  (queue-new-transaction [_ ledger-id tx-id txn opts]
+  (-queue-new-transaction [_ txn-msg]
     (go
-      (let [event-msg (messages/queue-new-transaction ledger-id tx-id txn opts)]
-        (async/offer! tx-queue event-msg)))))
+      (async/offer! tx-queue txn-msg))))
 
 (defn parse-opts
   "Extract the opts from the transaction and keywordify the top level keys."

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -11,7 +11,7 @@
             [fluree.server.handlers.shared :refer [deref!]]))
 
 (defrecord StandaloneTransactor [tx-queue]
-  consensus/TxGroup
+  consensus/Transactor
   (-queue-new-ledger [_ ledger-msg]
     (go
       (async/offer! tx-queue ledger-msg)))

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -5,10 +5,10 @@
             [fluree.db.util.core :refer [get-first-value]]
             [fluree.db.util.async :refer [go-try]]
             [fluree.db.util.log :as log]
-            [fluree.server.components.subscriptions :as subs]
+            [fluree.server.subscriptions :as subscriptions]
             [fluree.server.consensus :as consensus]
             [fluree.server.consensus.msg-format :as msg-format]
-            [fluree.server.consensus.watcher :as watcher]
+            [fluree.server.watcher :as watcher]
             [fluree.server.handlers.shared :refer [deref!]]))
 
 (defrecord StandaloneTransactor [tx-queue]
@@ -30,7 +30,7 @@
   [subscriptions watcher {:keys [ledger-id server tx-id commit-file-meta] :as handler-result}]
   (log/info (str "New Ledger successfully created by server " server ": " ledger-id " with tx-id: " tx-id "."))
   (watcher/deliver-watch watcher tx-id handler-result)
-  (subs/send-message-to-all subscriptions "ledger-created" ledger-id (:json commit-file-meta))
+  (subscriptions/send-message-to-all subscriptions "ledger-created" ledger-id (:json commit-file-meta))
   :success)
 
 (defn parse-opts
@@ -63,7 +63,7 @@
   [subscriptions watcher {:keys [ledger-id tx-id server commit-file-meta] :as commit-result}]
   (log/info "New transaction completed for" ledger-id "tx-id: " tx-id "by server:" server)
   (watcher/deliver-watch watcher tx-id commit-result)
-  (subs/send-message-to-all subscriptions "new-commit" ledger-id (:json commit-file-meta))
+  (subscriptions/send-message-to-all subscriptions "new-commit" ledger-id (:json commit-file-meta))
   :success)
 
 (defn transact!

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -16,14 +16,12 @@
   (queue-new-ledger [_ ledger-id tx-id txn opts]
     (go
       (let [event-msg (msg-format/queue-new-ledger ledger-id tx-id txn opts)]
-        (>! tx-queue event-msg)
-        true)))
+        (async/offer! tx-queue event-msg))))
 
   (queue-new-transaction [_ ledger-id tx-id txn opts]
     (go
       (let [event-msg (msg-format/queue-new-transaction ledger-id tx-id txn opts)]
-        (>! tx-queue event-msg)
-        true))))
+        (async/offer! tx-queue event-msg)))))
 
 (defn broadcast-new-ledger!
   "Responsible for producing the event broadcast to connected peers."

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -22,7 +22,7 @@
         success?  (async/put! tx-queue event-msg)]
     (async/go success?)))
 
-(defrecord LocalConsensus [tx-queue closed? close]
+(defrecord StandaloneTransactor [tx-queue]
   consensus/TxGroup
   (queue-new-ledger [_ ledger-id tx-id txn opts]
     (queue-new-ledger tx-queue ledger-id tx-id txn opts))
@@ -143,6 +143,6 @@
 
     (monitor-new-tx-queue config tx-queue)
 
-    (map->LocalConsensus {:tx-queue tx-queue
-                          :closed?  closed?
-                          :close    close-fn})))
+    (map->StandaloneTransactor {:tx-queue tx-queue
+                                :closed?  closed?
+                                :close    close-fn})))

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -2,7 +2,7 @@
   (:require [clojure.core.async :as async :refer [<! >! go]]
             [fluree.db.api :as fluree]
             [fluree.db.constants :as const]
-            [fluree.db.util.async :refer [go-try]]
+            [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.util.core :refer [get-first-value]]
             [fluree.db.util.log :as log]
             [fluree.server.consensus :as consensus]
@@ -91,7 +91,7 @@
     (try
       (let [[event-type event-msg] event
 
-            result (<! (case event-type
+            result (<? (case event-type
                          :ledger-create (create-ledger! conn subscriptions watcher event-msg)
                          :tx-queue      (transact! conn subscriptions watcher event-msg)))]
         result)

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -1,4 +1,4 @@
-(ns fluree.server.consensus.none
+(ns fluree.server.consensus.standalone
   (:require [clojure.core.async :as async]
             [fluree.db.constants :as const]
             [fluree.db.api :as fluree]

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -11,26 +11,19 @@
             [fluree.server.consensus.watcher :as watcher]
             [fluree.server.handlers.shared :refer [deref!]]))
 
-(defn queue-new-ledger
-  [tx-queue ledger-id tx-id txn opts]
-  (go
-    (let [event-msg (msg-format/queue-new-ledger ledger-id tx-id txn opts)]
-      (>! tx-queue event-msg)
-      true)))
-
-(defn queue-new-transaction
-  [tx-queue ledger-id tx-id txn opts]
-  (go
-    (let [event-msg (msg-format/queue-new-transaction ledger-id tx-id txn opts)]
-      (>! tx-queue event-msg)
-      true)))
-
 (defrecord StandaloneTransactor [tx-queue]
   consensus/TxGroup
   (queue-new-ledger [_ ledger-id tx-id txn opts]
-    (queue-new-ledger tx-queue ledger-id tx-id txn opts))
+    (go
+      (let [event-msg (msg-format/queue-new-ledger ledger-id tx-id txn opts)]
+      (>! tx-queue event-msg)
+      true)))
+
   (queue-new-transaction [_ ledger-id tx-id txn opts]
-    (queue-new-transaction tx-queue ledger-id tx-id txn opts)))
+    (go
+      (let [event-msg (msg-format/queue-new-transaction ledger-id tx-id txn opts)]
+      (>! tx-queue event-msg)
+      true))))
 
 (defn broadcast-new-ledger!
   "Responsible for producing the event broadcast to connected peers."

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -99,7 +99,7 @@
 
 (defn new-tx-queue
   [conn subscriptions watcher]
-  (let [tx-queue (async/chan 512)]
+  (let [tx-queue (async/chan 16)]
     (go
       (loop [i 0]
         (let [timeout-ch (async/timeout 5000)

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -134,15 +134,10 @@
 
 (defn start
   [config]
-  (let [tx-queue (async/chan)
-        closed?  (atom false)
-        close-fn (fn []
-                   (log/info "Closing local transaction queue.")
-                   (reset! closed? true)
-                   (async/close! tx-queue))]
-
+  (let [tx-queue (async/chan)]
     (monitor-new-tx-queue config tx-queue)
+    (->StandaloneTransactor tx-queue)))
 
-    (map->StandaloneTransactor {:tx-queue tx-queue
-                                :closed?  closed?
-                                :close    close-fn})))
+(defn stop
+  [{:keys [tx-queue] :as _transactor}]
+  (async/close! tx-queue))

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -40,7 +40,7 @@
           commit-result (deref!
                          ;; following uses :file-data? and will return map with {:keys [db data-file commit-file]}
                          (fluree/commit! ledger staged-db {:file-data? true}))
-          broadcast-msg (messages/new-ledger params commit-result)]
+          broadcast-msg (messages/ledger-created params commit-result)]
       (consensus/broadcast-new-ledger! subscriptions watcher broadcast-msg))))
 
 (defn transact!
@@ -59,7 +59,7 @@
                             deref!)
           commit-result (deref!
                          (fluree/commit! ledger staged-db {:file-data? true}))
-          broadcast-msg (messages/new-commit params commit-result)]
+          broadcast-msg (messages/transaction-committed params commit-result)]
       (consensus/broadcast-new-commit! subscriptions watcher broadcast-msg))))
 
 (defn process-event

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -1,5 +1,5 @@
 (ns fluree.server.consensus.standalone
-  (:require [clojure.core.async :as async :refer [<! >! go]]
+  (:require [clojure.core.async :as async :refer [<! go]]
             [fluree.db.api :as fluree]
             [fluree.db.constants :as const]
             [fluree.db.util.async :refer [<? go-try]]

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -41,7 +41,7 @@
                  (assoc opts (keyword k) v))
                {} string-opts)))
 
-(defn do-new-ledger
+(defn create-ledger!
   [conn subscriptions watcher {:keys [ledger-id txn opts tx-id] :as _params}]
   (go-try
     (let [create-opts    (parse-opts txn)
@@ -66,7 +66,7 @@
   (subs/send-message-to-all subscriptions "new-commit" ledger-id (:json commit-file-meta))
   :success)
 
-(defn do-transaction
+(defn transact!
   [conn subscriptions watcher {:keys [ledger-id tx-id txn opts] :as params}]
   (go-try
     (let [start-time    (System/currentTimeMillis)
@@ -92,8 +92,8 @@
       (let [[event-type event-msg] event
 
             result (<! (case event-type
-                         :ledger-create (do-new-ledger conn subscriptions watcher event-msg)
-                         :tx-queue      (do-transaction conn subscriptions watcher event-msg)))]
+                         :ledger-create (create-ledger! conn subscriptions watcher event-msg)
+                         :tx-queue      (transact! conn subscriptions watcher event-msg)))]
         result)
       (catch Exception e
         (log/error "Unexpected event message - expected two-tuple of [event-type event-data], "

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -2,6 +2,7 @@
   (:require [clojure.core.async :as async :refer [<! >! go]]
             [fluree.db.constants :as const]
             [fluree.db.api :as fluree]
+            [fluree.db.util.core :refer [get-first-value]]
             [fluree.db.util.async :refer [go-try]]
             [fluree.db.util.log :as log]
             [fluree.server.components.subscriptions :as subs]
@@ -42,11 +43,10 @@
 (defn parse-opts
   "Extract the opts from the transaction and keywordify the top level keys."
   [expanded-txn]
-  (-> expanded-txn
-      (get const/iri-opts)
-      (get 0)
-      (get "@value")
-      (->> (reduce-kv (fn [opts k v] (assoc opts (keyword k) v)) {}))))
+  (let [string-opts (get-first-value expanded-txn const/iri-opts)]
+    (reduce-kv (fn [opts k v]
+                 (assoc opts (keyword k) v))
+               {} string-opts)))
 
 (defn do-new-ledger
   [conn subscriptions watcher {:keys [ledger-id txn opts tx-id] :as _params}]

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -12,13 +12,11 @@
 
 (defrecord StandaloneTransactor [tx-queue]
   consensus/Transactor
-  (-queue-new-ledger [_ ledger-msg]
-    (go
-      (async/offer! tx-queue ledger-msg)))
+  (-queue-new-ledger [_ ledgerevent]
+    (go (async/offer! tx-queue ledgerevent)))
 
-  (-queue-new-transaction [_ txn-msg]
-    (go
-      (async/offer! tx-queue txn-msg))))
+  (-queue-new-transaction [_ txn-evt]
+    (go (async/offer! tx-queue txn-evt))))
 
 (defn parse-opts
   "Extract the opts from the transaction and keywordify the top level keys."
@@ -41,8 +39,8 @@
           commit-result (deref!
                          ;; following uses :file-data? and will return map with {:keys [db data-file commit-file]}
                          (fluree/commit! ledger staged-db {:file-data? true}))
-          broadcast-msg (events/transaction-committed params commit-result)]
-      (broadcast/announce-new-ledger! subscriptions watcher broadcast-msg))))
+          broadcast-evt (events/transaction-committed params commit-result)]
+      (broadcast/announce-new-ledger! subscriptions watcher broadcast-evt))))
 
 (defn transact!
   [conn subscriptions watcher {:keys [ledger-id tx-id txn opts] :as params}]
@@ -60,21 +58,21 @@
                             deref!)
           commit-result (deref!
                          (fluree/commit! ledger staged-db {:file-data? true}))
-          broadcast-msg (events/transaction-committed params commit-result)]
-      (broadcast/announce-new-commit! subscriptions watcher broadcast-msg))))
+          broadcast-evt (events/transaction-committed params commit-result)]
+      (broadcast/announce-new-commit! subscriptions watcher broadcast-evt))))
 
 (defn process-event
   [conn subscriptions watcher event]
   (go
     (try
-      (let [[event-type event-msg] event
+      (let [[event-type event-evt] event
 
             result (<! (case event-type
-                         :ledger-create (create-ledger! conn subscriptions watcher event-msg)
-                         :tx-queue      (transact! conn subscriptions watcher event-msg)))]
+                         :ledger-create (create-ledger! conn subscriptions watcher event-evt)
+                         :tx-queue      (transact! conn subscriptions watcher event-evt)))]
         (if (exception? result)
-          (let [error-msg (events/error event-msg result)]
-            (broadcast/announce-error! watcher error-msg))
+          (let [error-evt (events/error event-evt result)]
+            (broadcast/announce-error! watcher error-evt))
           result))
       (catch Exception e
         (log/error "Unexpected event message - expected two-tuple of [event-type event-data], "

--- a/src/fluree/server/consensus/subscriptions.clj
+++ b/src/fluree/server/consensus/subscriptions.clj
@@ -1,4 +1,4 @@
-(ns fluree.server.subscriptions
+(ns fluree.server.consensus.subscriptions
   (:require [clojure.core.async :as async]
             [fluree.db.util.json :as json]
             [fluree.db.util.log :as log]

--- a/src/fluree/server/consensus/watcher.clj
+++ b/src/fluree/server/consensus/watcher.clj
@@ -1,4 +1,4 @@
-(ns fluree.server.watcher
+(ns fluree.server.consensus.watcher
   "System to manage and track pending requests through consensus in order to
   respond with the result. When mutation requests happen over http (e.g.
   creating a new ledger), we want to wait for the operation to complete through

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -11,7 +11,7 @@
    [fluree.server.handlers.ledger :as ledger]
    [fluree.server.handlers.remote-resource :as remote]
    [fluree.server.handlers.transact :as srv-tx]
-   [fluree.server.subscriptions :as subscriptions]
+   [fluree.server.consensus.subscriptions :as subscriptions]
    [malli.core :as m]
    [muuntaja.core :as muuntaja]
    [muuntaja.format.core :as mf]

--- a/src/fluree/server/handlers/create.clj
+++ b/src/fluree/server/handlers/create.clj
@@ -10,7 +10,7 @@
    [fluree.server.consensus :as consensus]
    [fluree.server.handlers.shared :refer [deref! defhandler]]
    [fluree.server.handlers.transact :refer [derive-tx-id]]
-   [fluree.server.watcher :as watcher]))
+   [fluree.server.consensus.watcher :as watcher]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -10,7 +10,7 @@
             [fluree.json-ld.processor.api :as jld-processor]
             [fluree.server.consensus :as consensus]
             [fluree.server.handlers.shared :refer [defhandler deref!]]
-            [fluree.server.watcher :as watcher]))
+            [fluree.server.consensus.watcher :as watcher]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/fluree/server/system.clj
+++ b/src/fluree/server/system.clj
@@ -3,6 +3,7 @@
             [clojure.java.io :as io]
             [fluree.db.api :as fluree]
             [fluree.server.consensus.raft :as raft]
+            [fluree.server.consensus.standalone :as none]
             [fluree.server.handler :as handler]
             [fluree.server.subscriptions :as subscriptions]
             [fluree.server.watcher :as watcher]

--- a/src/fluree/server/system.clj
+++ b/src/fluree/server/system.clj
@@ -5,8 +5,8 @@
             [fluree.server.consensus.raft :as raft]
             [fluree.server.consensus.standalone :as standalone]
             [fluree.server.handler :as handler]
-            [fluree.server.subscriptions :as subscriptions]
-            [fluree.server.watcher :as watcher]
+            [fluree.server.consensus.subscriptions :as subscriptions]
+            [fluree.server.consensus.watcher :as watcher]
             [integrant.core :as ig]
             [meta-merge.core :refer [meta-merge]]
             [ring.adapter.jetty9 :as jetty]))

--- a/src/fluree/server/system.clj
+++ b/src/fluree/server/system.clj
@@ -3,7 +3,7 @@
             [clojure.java.io :as io]
             [fluree.db.api :as fluree]
             [fluree.server.consensus.raft :as raft]
-            [fluree.server.consensus.standalone :as none]
+            [fluree.server.consensus.standalone :as standalone]
             [fluree.server.handler :as handler]
             [fluree.server.subscriptions :as subscriptions]
             [fluree.server.watcher :as watcher]
@@ -51,6 +51,14 @@
 (defmethod ig/halt-key! :fluree/raft
   [_ {:keys [close] :as _raft-group}]
   (close))
+
+(defmethod ig/init-key :fluree/standalone
+  [_ {:keys [conn subscriptions watcher]}]
+  (standalone/start conn subscriptions watcher))
+
+(defmethod ig/halt-key! :fluree/standalone
+  [_ transactor]
+  (standalone/stop transactor))
 
 (defmethod ig/init-key :fluree/handler
   [_ {:keys [conn consensus watcher subscriptions]}]

--- a/src/fluree/server/system.clj
+++ b/src/fluree/server/system.clj
@@ -53,8 +53,8 @@
   (close))
 
 (defmethod ig/init-key :fluree/standalone
-  [_ {:keys [conn subscriptions watcher]}]
-  (standalone/start conn subscriptions watcher))
+  [_ {:keys [conn subscriptions watcher max-pending-txs]}]
+  (standalone/start conn subscriptions watcher max-pending-txs))
 
 (defmethod ig/halt-key! :fluree/standalone
   [_ transactor]

--- a/test/fluree/server/integration/test_system.clj
+++ b/test/fluree/server/integration/test_system.clj
@@ -57,14 +57,11 @@
 (defn run-test-server
   [run-tests]
   (set-server-ports)
-  (let [multi-addr-1     (str "/ip4/127.0.0.1/tcp/" @consensus-port-1)
-        config-overrides {:http/jetty        {:port @api-port}
+  (let [config-overrides {:http/jetty        {:port @api-port}
                           :fluree/watcher    {:max-tx-wait-ms 45000}
                           :fluree/connection {:method       :memory
                                               :parallelism  1
-                                              :cache-max-mb 100}
-                          :fluree/raft       {:servers     multi-addr-1
-                                              :this-server multi-addr-1}}
+                                              :cache-max-mb 100}}
         server           (system/start :dev config-overrides)]
     (run-tests)
     (system/stop server)))


### PR DESCRIPTION
This patch to the feature/no-consensus branch renames the consensus type from "none" to "standalone" and makes some changes to use explicit configuration values up front instead of passing around config maps, starts and stops the new standalone transactors with integrant, as well as some cleanup. 