### PR TITLE
Refactor/dev user ns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 !/.clj-kondo/config.edn
 !/.clj-kondo/ci-config.edn
 /.lsp/
+/dev/data/*

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps  {org.clojure/clojure            {:mvn/version "1.11.3"}
          org.clojure/core.async         {:mvn/version "1.6.681"}
          com.fluree/db                  {:git/url "https://github.com/fluree/db.git"
-                                         :git/sha "6bfc29a51da22dad60352a3e03b1588ce25c121f"}
+                                         :git/sha "9d94b2c52cf724f0df3a47a251d23dacc15f5474"}
          com.fluree/json-ld             {:git/url "https://github.com/fluree/json-ld.git"
                                          :git/sha "0958995acf5540271d1807fc6d8f2da131164e24"}
 

--- a/dev/logback.xml
+++ b/dev/logback.xml
@@ -13,8 +13,8 @@
 
     <logger name="user" level="ALL"/>
     <logger name="ch.qos.logback" level="WARN"/>
-    <logger name="fluree.server" level="TRACE"/>
-    <logger name="fluree.db" level="TRACE"/>
+    <logger name="fluree.server" level="INFO"/>
+    <logger name="fluree.db" level="INFO"/>
     <logger name="fluree.db.consensus" level="INFO"/>
     <logger name="fluree.db.messaging" level="INFO"/>
 

--- a/dev/src/configs.clj
+++ b/dev/src/configs.clj
@@ -1,0 +1,65 @@
+(ns configs
+  (:require [clojure.java.io :as io]
+            [aero.core :as aero]
+            [clojure.string :as str]
+            [meta-merge.core :refer [meta-merge]]
+            [integrant.core :as ig]))
+
+(defn load-config
+  "Loads aero config at given file path using profile keyword."
+  [config-file profile]
+  (-> config-file
+      io/resource
+      (aero/read-config {:profile profile})))
+
+(defn dev-config
+  []
+  (load-config "config.edn" :dev))
+
+;; raft configs
+
+(def server-1 "/ip4/127.0.0.1/tcp/62071")
+(def server-2 "/ip4/127.0.0.1/tcp/62072")
+(def server-3 "/ip4/127.0.0.1/tcp/62073")
+(def servers-str (str/join "," [server-1 server-2 server-3]))
+
+(def raft-single-server
+  (-> (dev-config)
+      (dissoc :fluree/standalone)
+      (assoc :fluree/raft
+             {
+              :storage-type     :file,
+              :ledger-directory "dev/data-raft"
+              :log-directory    "dev/data-raft"
+              :this-server      server-1
+              :servers          server-1
+              :catch-up-rounds  10
+              :entries-max      50,
+              :log-history      10,
+              :conn             (ig/ref :fluree/connection)
+              :watcher          (ig/ref :fluree/watcher)
+              :subscriptions    (ig/ref :fluree/subscriptions)})))
+
+(def raft-three-server-1
+  (meta-merge raft-single-server
+              {:http/jetty  {:port 58090}
+               :fluree/raft {:ledger-directory "dev/data-raft1"
+                             :log-directory    "dev/data-raft1"
+                             :this-server      server-1
+                             :servers          servers-str}}))
+
+(def raft-three-server-2
+  (meta-merge raft-single-server
+              {:http/jetty  {:port 58091}
+               :fluree/raft {:ledger-directory "dev/data-raft2"
+                             :log-directory    "dev/data-raft2"
+                             :this-server      server-2
+                             :servers          servers-str}}))
+
+(def raft-three-server-3
+  (meta-merge raft-single-server
+              {:http/jetty  {:port 58092}
+               :fluree/raft {:ledger-directory "dev/data-raft3"
+                             :log-directory    "dev/data-raft3"
+                             :this-server      server-3
+                             :servers          servers-str}}))

--- a/dev/src/http_calls.clj
+++ b/dev/src/http_calls.clj
@@ -4,62 +4,58 @@
             [fluree.server.consensus.network.multi-addr :refer [multi->map]]
             [user :as user]))
 
-(defn server-env->http-address
-  [server-env]
-  (let [{:keys [http/server fluree/consensus]} server-env
-        http-port (get server :port)
-        host      (-> consensus :consensus-this-server multi->map :host)]
-    (str "http://" host ":" http-port "/")))
 
 (def ledger-name "my/test")
 
-(def server-1-address (server-env->http-address user/server-1-env))
-(def server-2-address (server-env->http-address user/server-2-env))
-(def server-3-address (server-env->http-address user/server-3-env))
+(def server-1-address "http://localhost:58090/")
+(def server-2-address "http://localhost:58091/")
+(def server-3-address "http://localhost:58092/")
 
 
 (comment
 
-  (-> (client/get (str server-1-address "swagger.json"))
-      :body
-      (json/parse false))
+ (-> (client/get (str server-1-address "swagger.json"))
+     :body
+     (json/parse false))
 
-  (-> (client/post (str server-1-address "fluree/create")
-                   {:body               (json/stringify-UTF8
-                                          {
-                                           "@context" {"f" "https://ns.flur.ee/ledger#"}
-                                           "f:ledger" ledger-name
-                                           "@graph"   {"id"      "ex:test1"
-                                                       "ex:name" "Brian"}})
-                    ;:headers {"X-Api-Version" "2"}
-                    :content-type       :json
-                    :socket-timeout     1000 ;; in milliseconds
-                    :connection-timeout 1000 ;; in milliseconds
-                    :accept             :json}))
+ (-> (client/post (str server-1-address "fluree/create")
+                  {:body               (json/stringify-UTF8
+                                        {
+                                         "@context" {"ex" "http://example.org/"}
+                                         "ledger"   ledger-name
+                                         "insert"   {"@id"     "ex:test1"
+                                                     "ex:name" "Brian"}})
+                   ;:headers {"X-Api-Version" "2"}
+                   :content-type       :json
+                   :socket-timeout     1000 ;; in milliseconds
+                   :connection-timeout 1000 ;; in milliseconds
+                   :accept             :json}))
 
-  (-> (client/post (str server-1-address "fluree/transact")
-                   {:body               (json/stringify-UTF8
-                                          {"@context" {"f" "https://ns.flur.ee/ledger#"}
-                                           "f:ledger" ledger-name
-                                           "@graph"   {"id"      "ex:test2"
-                                                       "ex:name" "Brian2"}})
-                    ;:headers {"X-Api-Version" "2"}
-                    :content-type       :json
-                    :socket-timeout     1000 ;; in milliseconds
-                    :connection-timeout 1000 ;; in milliseconds
-                    :accept             :json}))
+ (-> (client/post (str server-1-address "fluree/transact")
+                  {:body               (json/stringify-UTF8
+                                        {"@context" {"ex" "http://example.org/"}
+                                         "ledger"   ledger-name
+                                         "insert"   {"@id"     "ex:test2"
+                                                     "ex:name" "Brian2"}})
+                   ;:headers {"X-Api-Version" "2"}
+                   :content-type       :json
+                   :socket-timeout     1000 ;; in milliseconds
+                   :connection-timeout 1000 ;; in milliseconds
+                   :accept             :json}))
 
-  (-> (client/post (str server-1-address "fluree/query")
-                   {:body               (json/stringify-UTF8
-                                          {"select" {"?s" ["*"]}
-                                           "from"   ledger-name
-                                           "where"  [["?s" "ex:name" nil]]})
-                    ;:headers {"X-Api-Version" "2"}
-                    :content-type       :json
-                    :socket-timeout     1000 ;; in milliseconds
-                    :connection-timeout 1000 ;; in milliseconds
-                    :accept             :json})
-      :body
-      (json/parse false))
+ (-> (client/post (str server-1-address "fluree/query")
+                  {:body               (json/stringify-UTF8
+                                        {"@context" {"ex" "http://example.org/"}
+                                         "select"   {"?s" ["*"]}
+                                         "from"     ledger-name
+                                         "where"    {"@id"     "?s"
+                                                     "ex:name" nil}})
+                   ;:headers {"X-Api-Version" "2"}
+                   :content-type       :json
+                   :socket-timeout     1000 ;; in milliseconds
+                   :connection-timeout 1000 ;; in milliseconds
+                   :accept             :json})
+     :body
+     (json/parse false))
 
-  )
+ )

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -7,6 +7,8 @@
             [clojure.java.io :as io]
             [fluree.server.system :as system]
             [fluree.db.util.log :as log]
+            [aero.core :as aero]
+            [meta-merge.core :refer [meta-merge]]
             [integrant.core :as ig]
             [integrant.repl :refer [clear go halt init reset reset-all]]))
 
@@ -39,3 +41,31 @@
    :fluree/connection {:method :remote
                        :servers "http://localhost:58090"}
    :fluree/consensus {:consensus-type :none}})
+
+(defn load-config
+  "Loads aero config at given file path using profile keyword."
+  [config-file profile]
+  (-> config-file
+      io/resource
+      (aero/read-config {:profile profile})))
+
+(defn dev-config
+  []
+  (ig/expand
+   (load-config "config.edn" :dev)))
+
+;; register dev-config as default
+(integrant.repl/set-prep! dev-config)
+
+
+(defn start!
+  "Starts dev repl"
+  []
+  (go))
+
+(comment
+
+ (start!)
+
+
+ )

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -12,36 +12,6 @@
             [integrant.core :as ig]
             [integrant.repl :refer [clear go halt init reset reset-all]]))
 
-;; Three Server Configuration
-(def server-1 "/ip4/127.0.0.1/tcp/62071")
-(def server-2 "/ip4/127.0.0.1/tcp/62072")
-(def server-3 "/ip4/127.0.0.1/tcp/62073")
-(def servers-str (str/join "," [server-1 server-2 server-3]))
-
-(def server-1-overrides
-  {:http/jetty        {:port 58090}
-   :fluree/connection {:storage-path "data/srv1"}
-   :fluree/consensus  {:servers servers-str
-                       :this-server server-1}})
-
-(def server-2-overrides
-  {:http/server       {:port 58091}
-   :fluree/connection {:storage-path "data/srv2"}
-   :fluree/consensus  {:consensus-servers     servers-str
-                       :consensus-this-server server-2}})
-
-(def server-3-overrides
-  {:http/server       {:port 58092}
-   :fluree/connection {:storage-path "data/srv3"}
-   :fluree/consensus  {:consensus-servers     servers-str
-                       :consensus-this-server server-3}})
-
-(def query-server-1-overrides
-  {:http/server {:port 58095}
-   :fluree/connection {:method :remote
-                       :servers "http://localhost:58090"}
-   :fluree/consensus {:consensus-type :none}})
-
 (defn load-config
   "Loads aero config at given file path using profile keyword."
   [config-file profile]
@@ -54,15 +24,25 @@
   (ig/expand
    (load-config "config.edn" :dev)))
 
-;; register dev-config as default
-(integrant.repl/set-prep! dev-config)
+;; Register dev-config as the default config
+(def sys-config (dev-config))
+
+(defn set-config!
+  "Sets a new config for use with (go)"
+  [config]
+  (alter-var-root #'sys-config (constantly config)))
+
+(integrant.repl/set-prep! (fn [] sys-config))
 
 
 (defn start!
-  "Starts dev repl"
-  ([] (go))
-  ([overrides]
-   (go (meta-merge overrides))))
+  "Starts dev repl. Optionally provide a config
+  to start with."
+  ([]
+   (go))
+  ([config]
+   (set-config! (ig/expand config))
+   (go)))
 
 (comment
 

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -60,8 +60,9 @@
 
 (defn start!
   "Starts dev repl"
-  []
-  (go))
+  ([] (go))
+  ([overrides]
+   (go (meta-merge overrides))))
 
 (comment
 

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -4,28 +4,14 @@
             [fluree.server.handlers.create :as create-handler]
             [fluree.server.consensus.raft.handler :as consensus-handler]
             [fluree.server.consensus.raft]
-            [clojure.java.io :as io]
             [fluree.server.system :as system]
             [fluree.db.util.log :as log]
-            [aero.core :as aero]
-            [meta-merge.core :refer [meta-merge]]
+            [configs :as configs]
             [integrant.core :as ig]
             [integrant.repl :refer [clear go halt init reset reset-all]]))
 
-(defn load-config
-  "Loads aero config at given file path using profile keyword."
-  [config-file profile]
-  (-> config-file
-      io/resource
-      (aero/read-config {:profile profile})))
-
-(defn dev-config
-  []
-  (ig/expand
-   (load-config "config.edn" :dev)))
-
 ;; Register dev-config as the default config
-(def sys-config (dev-config))
+(def sys-config (ig/expand (configs/dev-config)))
 
 (defn set-config!
   "Sets a new config for use with (go)"
@@ -33,7 +19,6 @@
   (alter-var-root #'sys-config (constantly config)))
 
 (integrant.repl/set-prep! (fn [] sys-config))
-
 
 (defn start!
   "Starts dev repl. Optionally provide a config
@@ -46,7 +31,9 @@
 
 (comment
 
- (start!)
+ (start!) ;; default :dev profile config
+
+ (start! configs/raft-single-server)
 
 
  )

--- a/resources/config-raft.edn
+++ b/resources/config-raft.edn
@@ -4,7 +4,7 @@
                                       50]
                :catch-up-rounds  #or [#env FLUREE_RAFT_CATCH_UP_ROUNDS
                                       10]
-               :storage-type     #or [#keyword #env FLUREE_RAFT_STORAGE_TYPE
+               :storage-type     #keyword #or [#env FLUREE_RAFT_STORAGE_TYPE
                                       :file]
                :servers          #or [#env FLUREE_RAFT_SERVERS
                                       #profile {:dev    "/ip4/127.0.0.1/tcp/62071"

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -7,7 +7,7 @@
                                                     :prod   4
                                                     :docker 4}]
                      :storage-path   #or [#env FLUREE_STORAGE_PATH
-                                          #profile {:dev    "data"
+                                          #profile {:dev    "dev/data"
                                                     :prod   "data"
                                                     :docker "data"}]
                      :cache-max-mb   #or [#env FLUREE_CACHE_MAX_MB ;; integer, in MB

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,8 +1,4 @@
-{:fluree/connection {:remote-servers #or [#env FLUREE_REMOTE_SERVERS
-                                          #profile {:dev    "http://127.0.0.1:58090"
-                                                    :prod   nil
-                                                    :docker nil}]
-                     :method         #or [#env FLUREE_STORAGE_METHOD
+{:fluree/connection {:method         #or [#env FLUREE_STORAGE_METHOD
                                           #profile {:dev    :file
                                                     :prod   :file
                                                     :docker :file}]

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -14,8 +14,8 @@
                                           #profile {:dev    100
                                                     :prod   1000
                                                     :docker 1000}]
-                     :defaults       {:indexer {:reindex-min-bytes 1000
-                                                :reindex-max-bytes 10000000}}}
+                     :defaults       {:indexer {:reindex-min-bytes 100000 ; 100KB
+                                                :reindex-max-bytes 50000000}}} ; 50MB
 
  :fluree/watcher {:max-tx-wait-ms #or [#env FLUREE_MAX_TX_WAIT_MS
                                        #profile {:dev    45000


### PR DESCRIPTION
This adds some simple REPL startup back to the user namespace, and fixes the http-api calls namespace used for issuing/debugging http calls to the server from the REPL.

I wanted to make sure how this is done makes sense to everyone.

The query-server config has to get re-tested with the changes, and I plan to add a config to startup a query-server only. I don't think anyone has tried that in a while and it doesn't appear the config as it stands is current for that purpose.

I also plan to have a 3-server raft config out of the box startup function similar to what we used to have.