### PR TITLE
Refactor/dev namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 !/.clj-kondo/config.edn
 !/.clj-kondo/ci-config.edn
 /.lsp/
+/dev/data/*

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "fd294a379da36a9abd606a05864015e0b6051a1d"}
+                                :git/sha "1460edfc1cfe1aa226c9019dfa2f393748bc3266"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "0958995acf5540271d1807fc6d8f2da131164e24"}
 

--- a/dev/logback.xml
+++ b/dev/logback.xml
@@ -13,8 +13,8 @@
 
     <logger name="user" level="ALL"/>
     <logger name="ch.qos.logback" level="WARN"/>
-    <logger name="fluree.server" level="TRACE"/>
-    <logger name="fluree.db" level="TRACE"/>
+    <logger name="fluree.server" level="INFO"/>
+    <logger name="fluree.db" level="INFO"/>
     <logger name="fluree.db.consensus" level="INFO"/>
     <logger name="fluree.db.messaging" level="INFO"/>
 

--- a/dev/src/http_calls.clj
+++ b/dev/src/http_calls.clj
@@ -4,62 +4,58 @@
             [fluree.server.consensus.network.multi-addr :refer [multi->map]]
             [user :as user]))
 
-(defn server-env->http-address
-  [server-env]
-  (let [{:keys [http/server fluree/consensus]} server-env
-        http-port (get server :port)
-        host      (-> consensus :consensus-this-server multi->map :host)]
-    (str "http://" host ":" http-port "/")))
 
 (def ledger-name "my/test")
 
-(def server-1-address (server-env->http-address user/server-1-env))
-(def server-2-address (server-env->http-address user/server-2-env))
-(def server-3-address (server-env->http-address user/server-3-env))
+(def server-1-address "http://localhost:58090/")
+(def server-2-address "http://localhost:58091/")
+(def server-3-address "http://localhost:58092/")
 
 
 (comment
 
-  (-> (client/get (str server-1-address "swagger.json"))
-      :body
-      (json/parse false))
+ (-> (client/get (str server-1-address "swagger.json"))
+     :body
+     (json/parse false))
 
-  (-> (client/post (str server-1-address "fluree/create")
-                   {:body               (json/stringify-UTF8
-                                          {
-                                           "@context" {"f" "https://ns.flur.ee/ledger#"}
-                                           "f:ledger" ledger-name
-                                           "@graph"   {"id"      "ex:test1"
-                                                       "ex:name" "Brian"}})
-                    ;:headers {"X-Api-Version" "2"}
-                    :content-type       :json
-                    :socket-timeout     1000 ;; in milliseconds
-                    :connection-timeout 1000 ;; in milliseconds
-                    :accept             :json}))
+ (-> (client/post (str server-1-address "fluree/create")
+                  {:body               (json/stringify-UTF8
+                                        {
+                                         "@context" {"ex" "http://example.org/"}
+                                         "ledger"   ledger-name
+                                         "insert"   {"@id"     "ex:test1"
+                                                     "ex:name" "Brian"}})
+                   ;:headers {"X-Api-Version" "2"}
+                   :content-type       :json
+                   :socket-timeout     1000 ;; in milliseconds
+                   :connection-timeout 1000 ;; in milliseconds
+                   :accept             :json}))
 
-  (-> (client/post (str server-1-address "fluree/transact")
-                   {:body               (json/stringify-UTF8
-                                          {"@context" {"f" "https://ns.flur.ee/ledger#"}
-                                           "f:ledger" ledger-name
-                                           "@graph"   {"id"      "ex:test2"
-                                                       "ex:name" "Brian2"}})
-                    ;:headers {"X-Api-Version" "2"}
-                    :content-type       :json
-                    :socket-timeout     1000 ;; in milliseconds
-                    :connection-timeout 1000 ;; in milliseconds
-                    :accept             :json}))
+ (-> (client/post (str server-1-address "fluree/transact")
+                  {:body               (json/stringify-UTF8
+                                        {"@context" {"ex" "http://example.org/"}
+                                         "ledger"   ledger-name
+                                         "insert"   {"@id"     "ex:test2"
+                                                     "ex:name" "Brian2"}})
+                   ;:headers {"X-Api-Version" "2"}
+                   :content-type       :json
+                   :socket-timeout     1000 ;; in milliseconds
+                   :connection-timeout 1000 ;; in milliseconds
+                   :accept             :json}))
 
-  (-> (client/post (str server-1-address "fluree/query")
-                   {:body               (json/stringify-UTF8
-                                          {"select" {"?s" ["*"]}
-                                           "from"   ledger-name
-                                           "where"  [["?s" "ex:name" nil]]})
-                    ;:headers {"X-Api-Version" "2"}
-                    :content-type       :json
-                    :socket-timeout     1000 ;; in milliseconds
-                    :connection-timeout 1000 ;; in milliseconds
-                    :accept             :json})
-      :body
-      (json/parse false))
+ (-> (client/post (str server-1-address "fluree/query")
+                  {:body               (json/stringify-UTF8
+                                        {"@context" {"ex" "http://example.org/"}
+                                         "select"   {"?s" ["*"]}
+                                         "from"     ledger-name
+                                         "where"    {"@id"     "?s"
+                                                     "ex:name" nil}})
+                   ;:headers {"X-Api-Version" "2"}
+                   :content-type       :json
+                   :socket-timeout     1000 ;; in milliseconds
+                   :connection-timeout 1000 ;; in milliseconds
+                   :accept             :json})
+     :body
+     (json/parse false))
 
-  )
+ )

--- a/resources/config-raft.json
+++ b/resources/config-raft.json
@@ -1,13 +1,46 @@
 {
+  "connection": {
+    "storageMethod": "file",
+    "parallelism": 4,
+    "storagePath": "dev/data/raft",
+    "cacheMaxMb": 1000,
+    "defaults": {
+      "index": {
+        "reindexMinBytes": 100000,
+        "reindexMaxBytes": 10000000
+      }
+    }
+  },
   "consensus": {
     "protocol": "raft",
     "logHistory": 10,
-    "entriesMax": 50,
+    "entriesMax": 200,
     "catchUpRounds": 10,
-    "storageType": "file",
-    "servers": "/ip4/127.0.0.1/tcp/62071",
-    "this-server": "/ip4/127.0.0.1/tcp/62071",
-    "log-directory": "data/raft",
-    "ledger-directory": "data/ledger"
+    "servers": [
+      "/ip4/127.0.0.1/tcp/62071"
+    ],
+    "thisServer": "/ip4/127.0.0.1/tcp/62071",
+    "logDirectory": "data/raftlog",
+    "ledgerDirectory": "data"
+  },
+  "http": {
+    "server": "jetty",
+    "port": 8090,
+    "maxTxnWaitMs": 120000
+  },
+  "profiles": {
+    "dev": {
+      "connection": {
+        "storagePath": "dev/data/raft",
+        "cacheMaxMb": 200
+      },
+      "consensus": {
+        "logDirectory": "dev/data/raft/raftlog",
+        "ledgerDirectory": "dev/data/raft"
+      },
+      "http": {
+        "port": 58090
+      }
+    }
   }
 }

--- a/resources/config.json
+++ b/resources/config.json
@@ -6,7 +6,7 @@
     "cacheMaxMb": 1000,
     "defaults": {
       "index": {
-        "reindexMinBytes": 1000,
+        "reindexMinBytes": 100000,
         "reindexMaxBytes": 10000000,
         "maxOldIndexes": 3
       }
@@ -14,19 +14,18 @@
   },
   "consensus": {
     "protocol": "standalone",
-    "maxPendingTxns": 16
+    "maxPendingTxns": 42
   },
   "http": {
     "server": "jetty",
     "port": 8090,
-    "maxTxnWaitMs": 4500
+    "maxTxnWaitMs": 120000
   },
   "profiles": {
     "dev": {
       "connection": {
-        "remoteServers": ["http://127.0.0.1:58090"],
-        "parallelism": 1,
-        "cacheMaxMb": 100
+        "storagePath": "dev/data",
+        "cacheMaxMb": 200
       },
       "http": {
         "port": 58090

--- a/src/fluree/server/consensus/raft.clj
+++ b/src/fluree/server/consensus/raft.clj
@@ -492,11 +492,7 @@
 
 (defn add-server-configs
   [{:keys [this-server servers] :as raft-state}]
-  (when-not (string? servers)
-    (throw (ex-info (str "Cannot start raft without a list of participating servers separated by a comma or semicolon. "
-                         "If this is a single server, please specify this-server instead of servers.")
-                    {:status 400 :error :db/invalid-server-address})))
-  (let [servers*           (mapv str/trim (str/split servers #"[,;]"))
+  (let [servers*           (mapv str/trim servers)
         this-server*       (if this-server
                              (str/trim this-server)
                              (if (= 1 (count servers*))


### PR DESCRIPTION
This replaces https://github.com/fluree/server/pull/77 based on the new config feature. It is based on top of https://github.com/fluree/server/pull/78.

This 
- adds some REPL tools to the user namespace
- has a working single-server RAFT config with simple user ns startup
- Adjusts some of our default settings to be more reasonable (open to debate)
- Fixes http-api call dev namespace
- excludes `dev/data` director in .gitignore, and dev namespaces now by default write data to that directory
- 