### PR TITLE
Fix/multi server raft

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "1460edfc1cfe1aa226c9019dfa2f393748bc3266"}
+                                :git/sha "064d63dd28ea26519c501e1090b8ad18adb58b27"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "0958995acf5540271d1807fc6d8f2da131164e24"}
 

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -36,4 +36,10 @@
  ;; single-server raft config startup
  (start! (config/load-resource "config-raft.json" :dev))
 
+ ;; 3 server raft config startup
+ (start! (config/load-resource "config-raft.json" :dev-3-server-1))
+ (start! (config/load-resource "config-raft.json" :dev-3-server-2))
+ (start! (config/load-resource "config-raft.json" :dev-3-server-3))
+
+
  )

--- a/resources/config-raft.json
+++ b/resources/config-raft.json
@@ -1,4 +1,7 @@
 {
+  "server": {
+    "storagePath": "data"
+  },
   "connection": {
     "storageMethod": "file",
     "parallelism": 4,
@@ -30,19 +33,23 @@
   },
   "profiles": {
     "dev": {
+      "server": {
+        "storagePath": "dev/data/raft"
+      },
       "connection": {
-        "storagePath": "dev/data/raft",
         "cacheMaxMb": 200
       },
       "consensus": {
-        "logDirectory": "dev/data/raft/raftlog",
-        "ledgerDirectory": "dev/data/raft"
+        "logDirectory": "dev/data/raft/raftlog"
       },
       "http": {
         "port": 58090
       }
     },
     "dev-3-server-1": {
+      "server": {
+        "storagePath": "dev/data/raft1"
+      },
       "consensus": {
         "servers": [
           "/ip4/127.0.0.1/tcp/62071",
@@ -50,17 +57,19 @@
           "/ip4/127.0.0.1/tcp/62073"
         ],
         "thisServer": "/ip4/127.0.0.1/tcp/62071",
-        "logDirectory": "dev/data/raft1/raftlog",
-        "ledgerDirectory": "dev/data/raft1"
+        "logDirectory": "dev/data/raft1/raftlog"
       },
       "connection": {
-        "storagePath": "dev/data/raft1"
+        "cacheMaxMb": 200
       },
       "http": {
         "port": 58090
       }
     },
     "dev-3-server-2": {
+      "server": {
+        "storagePath": "dev/data/raft2"
+      },
       "consensus": {
         "servers": [
           "/ip4/127.0.0.1/tcp/62071",
@@ -68,17 +77,19 @@
           "/ip4/127.0.0.1/tcp/62073"
         ],
         "thisServer": "/ip4/127.0.0.1/tcp/62072",
-        "logDirectory": "dev/data/raft2/raftlog",
-        "ledgerDirectory": "dev/data/raft2"
+        "logDirectory": "dev/data/raft2/raftlog"
       },
       "connection": {
-        "storagePath": "dev/data/raft2"
+        "cacheMaxMb": 200
       },
       "http": {
         "port": 58091
       }
     },
     "dev-3-server-3": {
+      "server": {
+        "storagePath": "dev/data/raft3"
+      },
       "consensus": {
         "servers": [
           "/ip4/127.0.0.1/tcp/62071",
@@ -86,11 +97,10 @@
           "/ip4/127.0.0.1/tcp/62073"
         ],
         "thisServer": "/ip4/127.0.0.1/tcp/62073",
-        "logDirectory": "dev/data/raft3/raftlog",
-        "ledgerDirectory": "dev/data/raft3"
+        "logDirectory": "dev/data/raft3/raftlog"
       },
       "connection": {
-        "storagePath": "dev/data/raft3"
+        "cacheMaxMb": 200
       },
       "http": {
         "port": 58092

--- a/resources/config-raft.json
+++ b/resources/config-raft.json
@@ -2,7 +2,7 @@
   "connection": {
     "storageMethod": "file",
     "parallelism": 4,
-    "storagePath": "dev/data/raft",
+    "storagePath": "data",
     "cacheMaxMb": 1000,
     "defaults": {
       "index": {

--- a/resources/config-raft.json
+++ b/resources/config-raft.json
@@ -41,6 +41,60 @@
       "http": {
         "port": 58090
       }
+    },
+    "dev-3-server-1": {
+      "consensus": {
+        "servers": [
+          "/ip4/127.0.0.1/tcp/62071",
+          "/ip4/127.0.0.1/tcp/62072",
+          "/ip4/127.0.0.1/tcp/62073"
+        ],
+        "thisServer": "/ip4/127.0.0.1/tcp/62071",
+        "logDirectory": "dev/data/raft1/raftlog",
+        "ledgerDirectory": "dev/data/raft1"
+      },
+      "connection": {
+        "storagePath": "dev/data/raft1"
+      },
+      "http": {
+        "port": 58090
+      }
+    },
+    "dev-3-server-2": {
+      "consensus": {
+        "servers": [
+          "/ip4/127.0.0.1/tcp/62071",
+          "/ip4/127.0.0.1/tcp/62072",
+          "/ip4/127.0.0.1/tcp/62073"
+        ],
+        "thisServer": "/ip4/127.0.0.1/tcp/62072",
+        "logDirectory": "dev/data/raft2/raftlog",
+        "ledgerDirectory": "dev/data/raft2"
+      },
+      "connection": {
+        "storagePath": "dev/data/raft2"
+      },
+      "http": {
+        "port": 58091
+      }
+    },
+    "dev-3-server-3": {
+      "consensus": {
+        "servers": [
+          "/ip4/127.0.0.1/tcp/62071",
+          "/ip4/127.0.0.1/tcp/62072",
+          "/ip4/127.0.0.1/tcp/62073"
+        ],
+        "thisServer": "/ip4/127.0.0.1/tcp/62073",
+        "logDirectory": "dev/data/raft3/raftlog",
+        "ledgerDirectory": "dev/data/raft3"
+      },
+      "connection": {
+        "storagePath": "dev/data/raft3"
+      },
+      "http": {
+        "port": 58092
+      }
     }
   }
 }

--- a/resources/config.json
+++ b/resources/config.json
@@ -1,8 +1,10 @@
 {
+  "server": {
+    "storagePath": "data"
+  },
   "connection": {
     "storageMethod": "file",
     "parallelism": 4,
-    "storagePath": "data",
     "cacheMaxMb": 1000,
     "defaults": {
       "index": {
@@ -23,8 +25,10 @@
   },
   "profiles": {
     "dev": {
+      "server": {
+        "storagePath": "dev/data"
+      },
       "connection": {
-        "storagePath": "dev/data",
         "cacheMaxMb": 200
       },
       "http": {

--- a/src/fluree/server/config.clj
+++ b/src/fluree/server/config.clj
@@ -26,7 +26,7 @@
     ::connection-defaults [:map
                            [:index {:optional true} ::indexing-options]
                            [:did {:optional true} :string]]
-    ::file-connection [:map [:storage-path {:optional true} ::path]]
+    ::file-connection [:map]
     ::memory-connection [:map]
     ::ipfs-connection [:map [:ipfs-server ::server-address]]
     ::remote-connection [:map [:remote-servers [:sequential ::server-address]]]
@@ -46,6 +46,8 @@
                    [:ipfs ::ipfs-connection]
                    [:remote ::remote-connection]
                    [:s3 ::s3-connection]]]
+    ::server-config [:map
+                     [:storage-path {:optional true} ::path]]
     ::consensus-protocol [:enum
                           :raft :standalone]
     ::raft [:map
@@ -54,8 +56,7 @@
             [:catch-up-rounds {:optional true} pos-int?]
             [:servers [:sequential ::server-address]]
             [:this-server ::server-address]
-            [:log-directory {:optional true} ::path]
-            [:ledger-directory ::path]]
+            [:log-directory {:optional true} ::path]]
     ::standalone [:map [:max-pending-txns {:optional true} pos-int?]]
     ::consensus [:and
                  [:map [:protocol ::consensus-protocol]]
@@ -75,6 +76,7 @@
             [:multi {:dispatch :server}
              [:jetty ::jetty]]]
     ::config [:map {:closed true}
+              [:server ::server-config]
               [:connection ::connection]
               [:consensus ::consensus]
               [:http ::http]]}))
@@ -83,10 +85,10 @@
   (m/coercer ::config transform/string-transformer {:registry registry}))
 
 (def env-template
-  {:connection {:storage-method "FLUREE_STORAGE_METHOD"
+  {:server     {:storage-path "FLUREE_STORAGE_PATH"}
+   :connection {:storage-method "FLUREE_STORAGE_METHOD"
                 :parallelism    "FLUREE_CONNECTION_PARALLELISM"
                 :cache-max-mb   "FLUREE_CACHE_MAX_MB"
-                :storage-path   "FLUREE_STORAGE_PATH"
                 :remote-servers "FLUREE_REMOTE_SERVERS"
                 :ipfs-server    "FLUREE_IPFS_SERVER"
                 :s3-endpoint    "FLUREE_S3_ENDPOINT"
@@ -104,8 +106,7 @@
                 :storage-type     "FLUREE_RAFT_STORAGE_TYPE"
                 :servers          "FLUREE_RAFT_SERVERS"
                 :this-server      "FLUREE_RAFT_THIS_SERVER"
-                :log-directory    "FLUREE_RAFT_LOG_DIRECTORY"
-                :ledger-directory "FLUREE_RAFT_LEDGER_DIRECTORY"}
+                :log-directory    "FLUREE_RAFT_LOG_DIRECTORY"}
    :http       {:server          "FLUREE_HTTP_SERVER"
                 :port            "FLUREE_HTTP_API_PORT"
                 :max-txn-wait-ms "FLUREE_HTTP_MAX_TXN_WAIT_MS"}})

--- a/src/fluree/server/consensus/raft.clj
+++ b/src/fluree/server/consensus/raft.clj
@@ -463,7 +463,7 @@
 
 (defn add-state-machine
   "Add state machine configuration options needed for raft"
-  [{:keys [conn watcher subscriptions this-server command-chan
+  [{:keys [conn watcher subscriptions server this-server command-chan
            storage-ledger-read storage-ledger-write]
     :as raft-config}
    config-handler]
@@ -471,6 +471,7 @@
         state-machine-config {:fluree/conn                    conn
                               :fluree/watcher                 watcher
                               :fluree/subscriptions           subscriptions
+                              :fluree/server                  server
                               :consensus/command-chan         command-chan
                               :consensus/this-server          this-server
                               :consensus/state-atom           state-machine-atom
@@ -522,8 +523,10 @@
   (str/join "/" ["." "data" server-name directory-type ""]))
 
 (defn default-log-directory
-  [server-name]
-  (default-data-directory server-name "raftlog"))
+  [ledger-directory server-name]
+  (if ledger-directory
+    (str ledger-directory "/raftlog")
+    (default-data-directory server-name "raftlog")))
 
 (defn default-ledger-directory
   [server-name]
@@ -533,7 +536,7 @@
   [{:keys [log-directory ledger-directory this-server] :as raft-config}]
   (let [server-name       (name this-server)
         log-directory*    (-> log-directory
-                              (or (default-log-directory server-name))
+                              (or (default-log-directory ledger-directory server-name))
                               io-file/canonicalize-path)
         ledger-directory* (-> ledger-directory
                               (or (default-ledger-directory server-name))

--- a/src/fluree/server/consensus/raft/handlers/ledger_created.clj
+++ b/src/fluree/server/consensus/raft/handlers/ledger_created.clj
@@ -47,8 +47,8 @@
                  e)))))
 
 (defn clean-up-files
-  [{:keys [fluree/conn] :as _config} {:keys [ledger-id] :as _params}]
-  (let [local-path (fs/local-path (:storage-path conn))
+  [{:keys [fluree/server] :as _config} {:keys [ledger-id] :as _params}]
+  (let [local-path (fs/local-path (:storage-path server))
         ledger-dir (io/file local-path ledger-id)
         files      (reverse (file-seq ledger-dir))]
     (doseq [^File file files]

--- a/src/fluree/server/consensus/raft/handlers/new_commit.clj
+++ b/src/fluree/server/consensus/raft/handlers/new_commit.clj
@@ -16,11 +16,10 @@
   "Only writes file to disk if address is of type 'file'
 
   See fluree.db.conn.file namespace for key/vals contained in `file-meta` map."
-  [{:keys [fluree/conn]} {:keys [address json] :as _file-meta}]
+  [storage-path {:keys [address json] :as _file-meta}]
   (let [{:keys [method]} (storage/parse-address address)]
     (when (= "file" method)
-      (let [root       (-> conn :store :root) ;; TODO - 'store' needs a write-bytes fn or
-            path       (file-storage/storage-path root address)
+      (let [path       (file-storage/storage-path storage-path address)
             json-bytes (bytes/string->UTF8 json)]
         (async/<!! (fs/write-file path json-bytes))))))
 
@@ -35,16 +34,18 @@
   "Persist both the data-file and commit-file to disk only if redundant
   local-storage. If using a networked file system (e.g. S3, IPFS) the
   file is already stored by the leader with the respective service."
-  [{:keys [consensus/raft-state fluree/conn] :as config}
-   {:keys [data-file-meta commit-file-meta server] :as commit-result}]
+  [{:keys [consensus/raft-state fluree/conn fluree/server] :as _config}
+   {:keys [data-file-meta commit-file-meta] :as commit-result}]
   (go-try
-    (let [this-server (:this-server raft-state)]
-      (when (not= server this-server)
+    (let [this-server   (:this-server raft-state)
+          commit-server (:server commit-result)
+          storage-path  (:storage-path server)]
+      (when (not= commit-server this-server)
        ;; if server that created the new ledger is this server, the files
        ;; were already written - only other servers need to write file
         (when data-file-meta ;; if the commit is just being updated, there won't be more data (e.g. after indexing)
-          (write-file config data-file-meta))
-        (write-file config commit-file-meta)
+          (write-file storage-path data-file-meta))
+        (write-file storage-path commit-file-meta)
         (<? (push-nameservice conn commit-file-meta)))
       commit-result)))
 

--- a/src/fluree/server/consensus/raft/handlers/new_commit.clj
+++ b/src/fluree/server/consensus/raft/handlers/new_commit.clj
@@ -2,11 +2,11 @@
   (:require [clojure.core.async :as async]
             [fluree.db.nameservice.core :as nameservice]
             [fluree.db.storage :as storage]
+            [fluree.db.storage.file :as file-storage]
             [fluree.db.util.async :refer [<? go-try]]
             [fluree.db.util.bytes :as bytes]
-            [fluree.db.util.json :as json]
             [fluree.db.util.filesystem :as fs]
-            [fluree.db.storage.file :as file-storage]
+            [fluree.db.util.json :as json]
             [fluree.db.util.log :as log]
             [fluree.server.consensus.broadcast :as broadcast]))
 
@@ -38,15 +38,15 @@
   [{:keys [consensus/raft-state fluree/conn] :as config}
    {:keys [data-file-meta commit-file-meta server] :as commit-result}]
   (go-try
-   (let [this-server (:this-server raft-state)]
-     (when (not= server this-server)
+    (let [this-server (:this-server raft-state)]
+      (when (not= server this-server)
        ;; if server that created the new ledger is this server, the files
        ;; were already written - only other servers need to write file
-       (when data-file-meta ;; if the commit is just being updated, there won't be more data (e.g. after indexing)
-         (write-file config data-file-meta))
-       (write-file config commit-file-meta)
-       (<? (push-nameservice conn commit-file-meta)))
-     commit-result)))
+        (when data-file-meta ;; if the commit is just being updated, there won't be more data (e.g. after indexing)
+          (write-file config data-file-meta))
+        (write-file config commit-file-meta)
+        (<? (push-nameservice conn commit-file-meta)))
+      commit-result)))
 
 (defn update-ledger-state
   "Updates the latest commit in the ledger, and removes the processed transaction in the queue"

--- a/src/fluree/server/consensus/raft/handlers/new_commit.clj
+++ b/src/fluree/server/consensus/raft/handlers/new_commit.clj
@@ -17,7 +17,7 @@
 
   See fluree.db.conn.file namespace for key/vals contained in `file-meta` map."
   [{:keys [fluree/conn]} {:keys [address json] :as _file-meta}]
-  (let [{:keys [method local]} (storage/parse-address address)]
+  (let [{:keys [method]} (storage/parse-address address)]
     (when (= "file" method)
       (let [root       (-> conn :store :root) ;; TODO - 'store' needs a write-bytes fn or
             path       (file-storage/storage-path root address)

--- a/src/fluree/server/consensus/raft/handlers/new_commit.clj
+++ b/src/fluree/server/consensus/raft/handlers/new_commit.clj
@@ -3,6 +3,10 @@
             [fluree.db.nameservice.core :as nameservice]
             [fluree.db.storage :as storage]
             [fluree.db.util.async :refer [<? go-try]]
+            [fluree.db.util.bytes :as bytes]
+            [fluree.db.util.json :as json]
+            [fluree.db.util.filesystem :as fs]
+            [fluree.db.storage.file :as file-storage]
             [fluree.db.util.log :as log]
             [fluree.server.consensus.broadcast :as broadcast]))
 
@@ -15,7 +19,17 @@
   [{:keys [fluree/conn]} {:keys [address json] :as _file-meta}]
   (let [{:keys [method local]} (storage/parse-address address)]
     (when (= "file" method)
-      (async/<!! (storage/write (:store conn) local json)))))
+      (let [root       (-> conn :store :root) ;; TODO - 'store' needs a write-bytes fn or
+            path       (file-storage/storage-path root address)
+            json-bytes (bytes/string->UTF8 json)]
+        (async/<!! (fs/write-file path json-bytes))))))
+
+(defn push-nameservice
+  [conn {:keys [json address] :as _commit-file-meta}]
+  (let [commit-json (-> (json/parse json false)
+                        ;; address is not yet written into the commit file, add it
+                        (assoc "address" address))]
+    (nameservice/push! conn commit-json)))
 
 (defn store-ledger-files
   "Persist both the data-file and commit-file to disk only if redundant
@@ -24,15 +38,15 @@
   [{:keys [consensus/raft-state fluree/conn] :as config}
    {:keys [data-file-meta commit-file-meta server] :as commit-result}]
   (go-try
-    (let [this-server (:this-server raft-state)]
-      (when (not= server this-server)
-        ;; if server that created the new ledger is this server, the files
-        ;; were already written - only other servers need to write file
-        (when data-file-meta ;; if the commit is just being updated, there won't be more data (e.g. after indexing)
-          (write-file config data-file-meta))
-        (write-file config commit-file-meta)
-        (<? (nameservice/push! conn commit-file-meta)))
-      commit-result)))
+   (let [this-server (:this-server raft-state)]
+     (when (not= server this-server)
+       ;; if server that created the new ledger is this server, the files
+       ;; were already written - only other servers need to write file
+       (when data-file-meta ;; if the commit is just being updated, there won't be more data (e.g. after indexing)
+         (write-file config data-file-meta))
+       (write-file config commit-file-meta)
+       (<? (push-nameservice conn commit-file-meta)))
+     commit-result)))
 
 (defn update-ledger-state
   "Updates the latest commit in the ledger, and removes the processed transaction in the queue"

--- a/test/fluree/server/integration/test_system.clj
+++ b/test/fluree/server/integration/test_system.clj
@@ -58,7 +58,8 @@
 (defn run-test-server
   [run-tests]
   (set-server-ports)
-  (let [config {::config/connection {:storage-method :memory
+  (let [config {::config/server     {}
+                ::config/connection {:storage-method :memory
                                      :parallelism    1
                                      :cache-max-mb   100}
                 ::config/consensus  {:protocol         :standalone


### PR DESCRIPTION
This fixes multi-server raft.

The new nameservice changes had presented an initial issue, but once that was addressed the new file store created a new problem which is addressed here.

The way files are written to disk is not the same when used in consensus. For now, this pull the root directory from the file store in the conn and then bypasses the storage protocol as it doesn't do what we need done here.

There are a few strategies that could make this better and need to be considered as we finalize the storage protocols.
1) the connection storage path can be made available to consensus - as it currently stands it gets hidden in the 'store' protocol. The ledger directory of consensus should probably go away as it should realy never be different than the connection's file path.
2) a new file system store could be used just for consensus... but it is really just needs simple write/read which clojure.java.io mostly handle fine without needing anything else
3) a write-bytes method could be added to the store protocol which just writes bytes - nothing else.
4)?? 

Anyhow once we settle in on a method we can write up a ticket for it.

For now, it works again.
