### PR TITLE
Better defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,5 @@ EXPOSE 58090
 
 VOLUME ./data
 
-ENTRYPOINT ["java", "-jar", "server.jar"]
+ENTRYPOINT ["java", "-Xmx8g", "-jar", "server.jar"]
 CMD ["docker"]

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -8,7 +8,7 @@
         </encoder>
     </appender>
 
-    <logger name="fluree" level="debug" additivity="false">
+    <logger name="fluree" level="info" additivity="false">
         <appender-ref ref="CONSOLE"/>
     </logger>
 


### PR DESCRIPTION
This small patch changes some defaults for the docker environment. First, it uses 8GB in memory for the main java process, and it logs at the INFO level instead of debug.

We should make some changes in a subsequent pr that makes these entries configurable, but these defaults should suffice for now.