### PR TITLE
Shared LRU cache across connections

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "064d63dd28ea26519c501e1090b8ad18adb58b27"}
+                                :git/sha "55d75e53b2a68edab3d4fd4d96a1c80017d62beb"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "0958995acf5540271d1807fc6d8f2da131164e24"}
 

--- a/resources/config-raft.json
+++ b/resources/config-raft.json
@@ -1,12 +1,11 @@
 {
   "server": {
-    "storagePath": "data"
+    "storagePath": "data",
+    "cacheMaxMb": 1000
   },
   "connection": {
     "storageMethod": "file",
     "parallelism": 4,
-    "storagePath": "data",
-    "cacheMaxMb": 1000,
     "defaults": {
       "index": {
         "reindexMinBytes": 100000,
@@ -34,11 +33,9 @@
   "profiles": {
     "dev": {
       "server": {
-        "storagePath": "dev/data/raft"
-      },
-      "connection": {
+        "storagePath": "dev/data/raft",
         "cacheMaxMb": 200
-      },
+      }
       "consensus": {
         "logDirectory": "dev/data/raft/raftlog"
       },
@@ -48,7 +45,8 @@
     },
     "dev-3-server-1": {
       "server": {
-        "storagePath": "dev/data/raft1"
+        "storagePath": "dev/data/raft1",
+        "cacheMaxMb": 200
       },
       "consensus": {
         "servers": [
@@ -68,7 +66,8 @@
     },
     "dev-3-server-2": {
       "server": {
-        "storagePath": "dev/data/raft2"
+        "storagePath": "dev/data/raft2",
+        "cacheMaxMb": 200
       },
       "consensus": {
         "servers": [
@@ -79,16 +78,14 @@
         "thisServer": "/ip4/127.0.0.1/tcp/62072",
         "logDirectory": "dev/data/raft2/raftlog"
       },
-      "connection": {
-        "cacheMaxMb": 200
-      },
       "http": {
         "port": 58091
       }
     },
     "dev-3-server-3": {
       "server": {
-        "storagePath": "dev/data/raft3"
+        "storagePath": "dev/data/raft3",
+        "cacheMaxMb": 200
       },
       "consensus": {
         "servers": [
@@ -98,9 +95,6 @@
         ],
         "thisServer": "/ip4/127.0.0.1/tcp/62073",
         "logDirectory": "dev/data/raft3/raftlog"
-      },
-      "connection": {
-        "cacheMaxMb": 200
       },
       "http": {
         "port": 58092

--- a/resources/config.json
+++ b/resources/config.json
@@ -1,11 +1,11 @@
 {
   "server": {
-    "storagePath": "data"
+    "storagePath": "data",
+    "cacheMaxMb": 1000
   },
   "connection": {
     "storageMethod": "file",
     "parallelism": 4,
-    "cacheMaxMb": 1000,
     "defaults": {
       "index": {
         "reindexMinBytes": 100000,
@@ -26,9 +26,7 @@
   "profiles": {
     "dev": {
       "server": {
-        "storagePath": "dev/data"
-      },
-      "connection": {
+        "storagePath": "dev/data",
         "cacheMaxMb": 200
       },
       "http": {

--- a/src/fluree/server/config.clj
+++ b/src/fluree/server/config.clj
@@ -38,7 +38,6 @@
                   [:map
                    [:storage-method ::connection-storage-method]
                    [:parallelism {:optional true} pos-int?]
-                   [:cache-max-mb {:optional true} pos-int?]
                    [:defaults {:optional true} ::connection-defaults]]
                   [:multi {:dispatch :storage-method}
                    [:file ::file-connection]
@@ -47,6 +46,7 @@
                    [:remote ::remote-connection]
                    [:s3 ::s3-connection]]]
     ::server-config [:map
+                     [:cache-max-mb {:optional true} pos-int?]
                      [:storage-path {:optional true} ::path]]
     ::consensus-protocol [:enum
                           :raft :standalone]

--- a/src/fluree/server/system.clj
+++ b/src/fluree/server/system.clj
@@ -20,8 +20,9 @@
 
 (defmethod ig/expand-key ::config/connection
   [_ config]
-  (let [config* (assoc config :server (ig/ref :fluree/server)
-                              :cache (ig/ref :fluree/cache))]
+  (let [config* (assoc config
+                       :server (ig/ref :fluree/server)
+                       :cache (ig/ref :fluree/cache))]
     {:fluree/connection config*}))
 
 (defmethod ig/expand-key ::config/server


### PR DESCRIPTION
This moves the connection setting of `cacheMaxMb` to a server-level setting.

All connections leveraged on the same server should share the same LRU cache.

While technically there is more granular control available, it would in most circumstances under-utilize the machine resources - or if oversized to accommodate that, then leave the server susceptible to OOM failures.

We always have fluree/db, and people can write their own custom thin layer to do anything unique they want.

It utilizes the server-level config options in https://github.com/fluree/server/pull/80
