### PR TITLE
Fix/profile argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ EXPOSE 58090
 VOLUME ./data
 
 ENTRYPOINT ["java", "-Xmx8g", "-jar", "server.jar"]
-CMD ["docker"]
+CMD ["--profile=docker"]

--- a/src/fluree/server/main.clj
+++ b/src/fluree/server/main.clj
@@ -15,7 +15,7 @@
 
 (defn profile-string->keyword
   [s]
-  (-> s strip-leading-colon keyword))
+  (-> s str/trim strip-leading-colon keyword))
 
 (def cli-options
   [["-p" "--profile PROFILE" "Run profile"


### PR DESCRIPTION
This small patch updates the docker "CMD" string to use the updated fluree/server argument for specifying the profile. It also cleans up the passed in profile string to trim any surrounding whitespace. 