### PR TITLE
Feature/import api

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "fbb8c415678de864e7a105ccb099c8051eab38cb"}
+                                :git/sha "a5929ff537609dc8b1a686b2d8f5a81bc8053610"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "0958995acf5540271d1807fc6d8f2da131164e24"}
 
@@ -15,6 +15,7 @@
         ;; serialization, compression
         com.taoensso/nippy            {:mvn/version "3.4.0"}
         org.xerial.snappy/snappy-java {:mvn/version "1.1.10.5"}
+        org.clojars.quoll/raphael {:mvn/version "0.3.7"}
 
         ;; config
         org.clojure/tools.cli               {:mvn/version "1.1.230"}

--- a/src/fluree/server/consensus/events.clj
+++ b/src/fluree/server/consensus/events.clj
@@ -20,8 +20,9 @@
   message must be queued into the consensus state machine.
 
   Format is [event-name event-body]"
-  [ledger-id tx-id txn opts]
+  [ledger-id tx-id txn {:keys [parsed?] :as opts}]
   [:tx-queue {:txn       txn
+              :parsed?   parsed?
               :size      (count txn)
               :tx-id     tx-id
               :ledger-id ledger-id

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -190,6 +190,13 @@
         (handler req*))
       (handler (assoc req :raw-txn body-params)))))
 
+(defn wrap-set-ledger-id
+  [handler]
+  (fn [req]
+    (->> (get-in req [:headers "fluree-ledger"])
+         (assoc req :fluree/ledger-id)
+         (handler))))
+
 (defn wrap-set-fuel-header
   [handler]
   (fn [req]
@@ -334,6 +341,7 @@
                                    [10 wrap-cors]
                                    [10 (partial wrap-assoc-system conn consensus watcher)]
                                    [50 unwrap-credential]
+                                   [75 wrap-set-ledger-id]
                                    [100 wrap-set-fuel-header]
                                    [200 coercion/coerce-exceptions-middleware]
                                    [300 coercion/coerce-response-middleware]

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -237,6 +237,17 @@
                     (String. (.readAllBytes ^InputStream data)
                              ^String charset))))]}))
 
+(def turtle-format
+  "Turn a Turtle from an InputStream into a string that will be found on :body-params in the
+  request map."
+  (mf/map->Format
+   {:name "text/turtle"
+    :decoder [(fn [_]
+                (reify mf/Decode
+                  (decode [_ data charset]
+                    (String. (.readAllBytes ^InputStream data)
+                             ^String charset))))]}))
+
 (defn websocket-handler
   [conn subscriptions]
   ;; Mostly copy-pasta from
@@ -385,6 +396,7 @@
                            (-> muuntaja/default-options
                                (assoc-in [:formats "application/json"] json-format)
                                (assoc-in [:formats "application/sparql-query"] sparql-format)
+                               (assoc-in [:formats "text/turtle"] turtle-format)
                                (assoc-in [:formats "application/jwt"] jwt-format)))
               :middleware [swagger/swagger-feature
                            muuntaja-mw/format-negotiate-middleware

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -62,6 +62,12 @@
 (def TransactRequestBody
   (m/schema [:map-of :any :any]))
 
+(def ImportRequestBody
+  (m/schema [:or
+             [:string {:min 1}]
+             [:map-of :any :any]
+             [:sequential map?]]))
+
 (def TransactResponseBody
   (m/schema [:and
              [:map-of :keyword :any]
@@ -380,6 +386,13 @@
                               400 {:body ErrorResponse}
                               500 {:body ErrorResponse}}
                  :handler    #'srv-tx/default}}]
+        ["/import"
+         {:post {:summary    "Endpoint for importing RDF (json-ld or turtle/ttl) data."
+                 :parameters {:body ImportRequestBody}
+                 :responses  {200 {:body TransactResponseBody}
+                              400 {:body ErrorResponse}
+                              500 {:body ErrorResponse}}
+                 :handler    #'srv-tx/import}}]
         ["/query"
          {:get  query-endpoint
           :post query-endpoint}]

--- a/src/fluree/server/io/turtle.clj
+++ b/src/fluree/server/io/turtle.clj
@@ -1,0 +1,59 @@
+(ns fluree.server.io.turtle
+  (:require [fluree.db.query.exec.where :as exec.where]
+            [quoll.raphael.core :as raphael]
+            [quoll.rdf :as rdf :refer [RDF-TYPE RDF-FIRST RDF-REST RDF-NIL]]))
+
+(set! *warn-on-reflection* true)
+
+(defrecord Generator [counter bnode-cache namespaces]
+  raphael/NodeGenerator
+  (new-node [this]
+    [(update this :counter inc) (rdf/unsafe-blank-node (str "b" counter))])
+  (new-node [this label]
+    (if-let [node (get bnode-cache label)]
+      [this node]
+      (let [node (rdf/unsafe-blank-node (str "b" counter))]
+        [(-> this
+             (update :counter inc)
+             (update :bnode-cache assoc label node))
+         node])))
+  (add-base [this iri]
+    (update this :namespaces assoc :base (rdf/as-str iri)))
+  (add-prefix [this prefix iri]
+    (update this :namespaces assoc prefix (rdf/as-str iri)))
+  (iri-for [this prefix]
+    (get namespaces prefix))
+  (get-namespaces [this]
+    (dissoc namespaces :base))
+  (get-base [this]
+    (:base namespaces))
+  (new-qname [this prefix local]
+    (exec.where/match-iri (str (get namespaces prefix) local)))
+  (new-iri [this iri]
+    iri)
+  (new-literal [this s]
+    (-> exec.where/unmatched
+        (exec.where/match-value s)))
+  (new-literal [this s t]
+    (let [datatype (-> t ::exec.where/iri)]
+      (-> exec.where/unmatched
+          (exec.where/match-value s datatype))))
+  (new-lang-string [this s lang]
+    (-> exec.where/unmatched
+        (exec.where/match-lang s lang)))
+  (rdf-type [this]
+    RDF-TYPE)
+  (rdf-first [this] RDF-FIRST)
+  (rdf-rest [this] RDF-REST)
+  (rdf-nil [this] RDF-NIL))
+
+(defn new-generator
+  []
+  (->Generator 0 {} {}))
+
+(defn parse
+  [ttl]
+  (let [gen (new-generator)]
+    (-> ttl
+        (raphael/parse gen)
+        :triples)))


### PR DESCRIPTION
This adds a new 'import' API to fluree/server which accepts TURTLE (.ttl) and JSON-LD.

The main feature of this is that raw RDF data can be imported without converting it to JSON-LD... and even raw JSON-LD can be imported without having to reformat it by wrapping your JSON-LD file in {"insert": <json-ld>}.

The RDF data is just sent in the HTTP body, regardless of format.

To use the new API with TURTLE, the HTTP Headers must include:
```json
{"Content-Type":  "test/turtle",
 "Fluree-Ledger": "<fluree-ledger-name-here>"}
```

To use the API with JSON-LD, the HTTP Headers must include:
```json
{"Content-Type":  "application/json",
 "Fluree-Ledger": "<fluree-ledger-name-here>"}
```

For now, the ledger must already exist, and you are just 'importing' into an existing ledger. Having the ability to create a new ledger from an import is likely desirable, and it can be added fairly simply.
