### PR TITLE
Feature/closed mode

### DIFF
--- a/resources/config.json
+++ b/resources/config.json
@@ -22,7 +22,7 @@
     "server": "jetty",
     "port": 8090,
     "maxTxnWaitMs": 120000,
-    "rootIdentities": [],
+    "rootIdentities": ["did:fluree:<my-keypair-id>"],
     "closedMode": false
   },
   "profiles": {

--- a/resources/config.json
+++ b/resources/config.json
@@ -21,7 +21,9 @@
   "http": {
     "server": "jetty",
     "port": 8090,
-    "maxTxnWaitMs": 120000
+    "maxTxnWaitMs": 120000,
+    "rootIdentities": [],
+    "closedMode": false
   },
   "profiles": {
     "dev": {

--- a/src/fluree/server/config.clj
+++ b/src/fluree/server/config.clj
@@ -17,6 +17,7 @@
    (m/base-schemas)
    {::path string?
     ::server-address string?
+    ::auth-id string?
     ::connection-storage-method [:enum
                                  :ipfs :file :memory :s3 :remote]
     ::indexing-options [:map
@@ -72,7 +73,9 @@
             [:map
              [:server ::http-server]
              [:port ::http-port]
-             [:max-txn-wait-ms {:optional true} ::max-txn-wait-ms]]
+             [:max-txn-wait-ms {:optional true} ::max-txn-wait-ms]
+             [:root-identities {:optional true} [:sequential ::auth-id]]
+             [:closed-mode {:optional true} :boolean]]
             [:multi {:dispatch :server}
              [:jetty ::jetty]]]
     ::config [:map {:closed true}

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -113,12 +113,12 @@
         json-transformer    (-> default-transfomers :body :formats (get "application/json"))
         transformers        (assoc-in default-transfomers [:body :formats "application/jwt"] json-transformer)]
     (rcm/create
-      {:transformers transformers
-       :strip-extra-keys false
-       :error-keys #{}
-       :encode-error (fn [explained]
-                       {:error :db/invalid-query
-                        :message (v/format-explained-errors explained nil)})})))
+     {:transformers transformers
+      :strip-extra-keys false
+      :error-keys #{}
+      :encode-error (fn [explained]
+                      {:error :db/invalid-query
+                       :message (v/format-explained-errors explained nil)})})))
 
 (def history-coercer
   (let [default-transfomers (:transformers rcm/default-options)
@@ -127,12 +127,12 @@
                                 (assoc-in [:body :formats "application/jwt"] json-transformer)
                                 (assoc-in [:body :default] fql/fql-transformer))]
     (rcm/create
-      {:strip-extra-keys false
-       :error-keys #{}
-       :transformers transformers
-       :encode-error (fn [explained]
-                       {:error :db/invalid-query
-                        :message (v/format-explained-errors explained nil)})})))
+     {:strip-extra-keys false
+      :error-keys #{}
+      :transformers transformers
+      :encode-error (fn [explained]
+                      {:error :db/invalid-query
+                       :message (v/format-explained-errors explained nil)})})))
 
 (def query-endpoint
   {:summary    "Endpoint for submitting queries"

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -215,6 +215,7 @@
 
                 :else
                 (let [body-params* (cond-> body-params
+                                     ;; don't allow escalation of priveledge
                                      (not trusted-user) (update :opts dissoc :did :role))
                       req* (assoc req :server/closed-mode closed-mode :body-params body-params*)]
                   (handler req*))))

--- a/test/fluree/server/integration/closed_mode_test.clj
+++ b/test/fluree/server/integration/closed_mode_test.clj
@@ -1,8 +1,8 @@
 (ns fluree.server.integration.closed-mode-test
   (:require [clojure.test :as test :refer [deftest testing is]]
+            [fluree.crypto :as crypto]
             [fluree.server.integration.test-system
              :refer [api-post auth json-headers jwt-headers run-closed-test-server]]
-            [fluree.crypto :as crypto]
             [jsonista.core :as json]))
 
 (test/use-fixtures :once run-closed-test-server)
@@ -50,8 +50,8 @@
           (is (= 201 (:status resp))))))
     (testing "to transact"
       (let [transact-req {"ledger" "closed-test"
-                        "@context" ["https://ns.flur.ee" default-context]
-                        "insert" [{"@id" "ex:coin" "ex:name" "nickel"}]}
+                          "@context" ["https://ns.flur.ee" default-context]
+                          "insert" [{"@id" "ex:coin" "ex:name" "nickel"}]}
             resp (api-post :transact {:body (crypto/create-jws (json/write-value-as-string transact-req)
                                                                (:private auth))
                                       :headers jwt-headers})]
@@ -157,8 +157,8 @@
           (is (= {"error" "Missing credential."} (-> resp :body json/read-value))))))
     (testing "to transact"
       (let [transact-req {"ledger" "closed-test3"
-                        "@context" ["https://ns.flur.ee" default-context]
-                        "insert" [{"@id" "ex:coin" "ex:name" "nickel"}]}
+                          "@context" ["https://ns.flur.ee" default-context]
+                          "insert" [{"@id" "ex:coin" "ex:name" "nickel"}]}
             resp (api-post :transact {:body (json/write-value-as-string transact-req)
                                       :headers json-headers})]
         (testing "is rejected"

--- a/test/fluree/server/integration/closed_mode_test.clj
+++ b/test/fluree/server/integration/closed_mode_test.clj
@@ -1,0 +1,186 @@
+(ns fluree.server.integration.closed-mode-test
+  (:require [clojure.test :as test :refer [deftest testing is]]
+            [fluree.server.integration.test-system
+             :refer [api-post auth json-headers jwt-headers run-closed-test-server]]
+            [fluree.crypto :as crypto]
+            [jsonista.core :as json]))
+
+(test/use-fixtures :once run-closed-test-server)
+
+(def default-context
+  {"id"     "@id"
+   "type"   "@type"
+   "graph"  "@graph"
+   "xsd"    "http://www.w3.org/2001/XMLSchema#"
+   "rdf"    "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   "rdfs"   "http://www.w3.org/2000/01/rdf-schema#"
+   "sh"     "http://www.w3.org/ns/shacl#"
+   "schema" "http://schema.org/"
+   "skos"   "http://www.w3.org/2008/05/skos#"
+   "wiki"   "https://www.wikidata.org/wiki/"
+   "f"      "https://ns.flur.ee/ledger#"
+   "ex"     "http://example.com/ns/"})
+
+(def root-auth auth)
+(def non-root-auth
+  {:id "did:fluree:Tf4KTeKpWcZAJadKfJ4JUv84dkBYy5KFHod"
+   :private "8d542edcd3a11b4ca5faabe7c9fa09045d6f489b9461518dbd86c6c9e3b21fec",
+   :public "03ad2f0920fd7e8b77b422f0922f53abd260336be2a3fccdc1bfadd8d858da149b"})
+
+(deftest closed-mode
+  ;; all endpoints
+  (testing "root request"
+    (testing "to create"
+      (let [create-req {"@context" default-context
+                        "ledger" "closed-test"
+                        "insert" {"@graph"
+                                  [{"id" (:id auth)
+                                    "f:policyClass" {"id" "ex:RootPolicy"}
+                                    "type" "schema:Person"
+                                    "ex:name" "Root User"}
+                                   {"@id" "ex:defaultAllowView"
+                                    "@type" ["f:AccessPolicy" "ex:RootPolicy"]
+                                    "f:action" [{"@id" "f:view"} {"@id" "f:modify"}]
+                                    "f:query" {"@type" "@json"
+                                               "@value" {}}}]}}
+            resp (api-post :create {:body    (crypto/create-jws (json/write-value-as-string create-req)
+                                                                (:private auth))
+                                    :headers jwt-headers})]
+        (testing "is accepted"
+          (is (= 201 (:status resp))))))
+    (testing "to transact"
+      (let [transact-req {"ledger" "closed-test"
+                        "@context" ["https://ns.flur.ee" default-context]
+                        "insert" [{"@id" "ex:coin" "ex:name" "nickel"}]}
+            resp (api-post :transact {:body (crypto/create-jws (json/write-value-as-string transact-req)
+                                                               (:private auth))
+                                      :headers jwt-headers})]
+        (testing "is accepted"
+          (is (= 200 (:status resp))))))
+    (testing "to query"
+      (let [query-req {"from" "closed-test"
+                       "@context" default-context
+                       "where" [{"@id" "?s" "ex:name" "?name"}]
+                       "select" "?s"}
+            resp (api-post :query {:body (crypto/create-jws (json/write-value-as-string query-req)
+                                                            (:private auth))
+                                   :headers jwt-headers})]
+        (testing "is accepted"
+          (is (= 200 (:status resp)))
+          (is (= ["did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh" "ex:coin"]
+                 (-> resp :body json/read-value))))))
+    (testing "to query history"
+      (let [history-req {"from" "closed-test"
+                         "@context" default-context
+                         "history" "ex:coin"
+                         "t" {"from" 1 "to" "latest"}}
+            resp (api-post :history {:body (crypto/create-jws (json/write-value-as-string history-req)
+                                                              (:private auth))
+                                     :headers jwt-headers})]
+        (testing "is accepted"
+          (is (= 200 (:status resp)))
+          (is (= [{"f:retract" [],
+                   "f:assert" [{"ex:name" "nickel", "id" "ex:coin"}],
+                   "f:t" 2}]
+                 (-> resp :body json/read-value)))))))
+
+  (testing "non-root request"
+    (testing "to create"
+      (let [create-req {"ledger" "closed-test2"
+                        "@context" ["https://ns.flur.ee" default-context]
+                        "insert" {"@graph"
+                                  [{"id" (:id auth)
+                                    "f:policyClass" {"id" "ex:RootPolicy"}
+                                    "type" "schema:Person"
+                                    "ex:name" "Root User"}
+                                   {"@id" "ex:defaultAllowView"
+                                    "@type" ["f:AccessPolicy" "ex:RootPolicy"]
+                                    "f:action" [{"@id" "f:view"} {"@id" "f:modify"}]
+                                    "f:query" {"@type" "@json"
+                                               "@value" {}}}]}}
+            resp (api-post :create {:body    (crypto/create-jws (json/write-value-as-string create-req)
+                                                                (:private non-root-auth))
+                                    :headers jwt-headers})]
+        (testing "is rejected"
+          (is (= 403 (:status resp)))
+          (is (= {"error" "Untrusted credential."} (-> resp :body json/read-value))))))
+    (testing "to transact"
+      (let [create-req {"ledger" "closed-test"
+                        "@context" ["https://ns.flur.ee" default-context]
+                        "insert" [{"@id" "ex:coin" "ex:name" "nickel"}]}
+            resp (api-post :transact {:body (crypto/create-jws (json/write-value-as-string create-req)
+                                                               (:private non-root-auth))
+                                      :headers jwt-headers})]
+        (testing "is accepted"
+          (is (= 200 (:status resp))))))
+    (testing "to query"
+      (let [create-req {"from" "closed-test"
+                        "@context" default-context
+                        "where" [{"@id" "?s" "ex:name" "?name"}]
+                        "select" ["?s" "?name"]}
+            resp (api-post :query {:body (crypto/create-jws (json/write-value-as-string create-req)
+                                                            (:private non-root-auth))
+                                   :headers jwt-headers})]
+        (testing "is accepted"
+          (is (= 200 (:status resp)))
+          (is (= [] (-> resp :body json/read-value))))))
+    (testing "to query history"
+      (let [create-req {"@context" default-context
+                        "from" "closed-test"
+                        "history" "ex:coin"
+                        "t" {"from" 1}}
+            resp (api-post :history {:body (crypto/create-jws (json/write-value-as-string create-req)
+                                                              (:private non-root-auth))
+                                     :headers jwt-headers})]
+        (testing "is accepted"
+          (is (= 200 (:status resp)))
+          (is (= [] (-> resp :body json/read-value)))))))
+
+  (testing "unsigned request"
+    (testing "to create"
+      (let [create-req {"ledger" "closed-test3"
+                        "@context" ["https://ns.flur.ee" default-context]
+                        "insert" {"@graph"
+                                  [{"id" (:id auth)
+                                    "f:policyClass" {"id" "ex:RootPolicy"}
+                                    "type" "schema:Person"
+                                    "ex:name" "Root User"}
+                                   {"@id" "ex:defaultAllowView"
+                                    "@type" ["f:AccessPolicy" "ex:RootPolicy"]
+                                    "f:action" [{"@id" "f:view"} {"@id" "f:modify"}]
+                                    "f:query" {"@type" "@json"
+                                               "@value" {}}}]}}
+            resp (api-post :create {:body    (json/write-value-as-string create-req)
+                                    :headers json-headers})]
+        (testing "is rejected"
+          (is (= 400 (:status resp)))
+          (is (= {"error" "Missing credential."} (-> resp :body json/read-value))))))
+    (testing "to transact"
+      (let [transact-req {"ledger" "closed-test3"
+                        "@context" ["https://ns.flur.ee" default-context]
+                        "insert" [{"@id" "ex:coin" "ex:name" "nickel"}]}
+            resp (api-post :transact {:body (json/write-value-as-string transact-req)
+                                      :headers json-headers})]
+        (testing "is rejected"
+          (is (= 400 (:status resp)))
+          (is (= {"error" "Missing credential."} (-> resp :body json/read-value))))))
+    (testing "to query"
+      (let [query-req {"from" "closed-test3"
+                       "@context" default-context
+                       "where" [{"@id" "?s" "ex:name" "?name"}]
+                       "select" ["?s" "?name"]}
+            resp (api-post :query {:body (json/write-value-as-string query-req)
+                                   :headers json-headers})]
+        (testing "is accepted"
+          (is (= 400 (:status resp)))
+          (is (= {"error" "Missing credential."} (-> resp :body json/read-value))))))
+    (testing "to query history"
+      (let [history-req {"from" "closed-test3"
+                         "@context" default-context
+                         "commit" true
+                         "t" {"from" 1 "to" "latest"}}
+            resp (api-post :history {:body (json/write-value-as-string history-req)
+                                     :headers json-headers})]
+        (testing "is rejected"
+          (is (= 400 (:status resp)))
+          (is (= {"error" "Missing credential."} (-> resp :body json/read-value))))))))

--- a/test/fluree/server/integration/closed_mode_test.clj
+++ b/test/fluree/server/integration/closed_mode_test.clj
@@ -34,7 +34,7 @@
       (let [create-req {"@context" default-context
                         "ledger" "closed-test"
                         "insert" {"@graph"
-                                  [{"id" (:id auth)
+                                  [{"id" (:id root-auth)
                                     "f:policyClass" {"id" "ex:RootPolicy"}
                                     "type" "schema:Person"
                                     "ex:name" "Root User"}
@@ -44,7 +44,7 @@
                                     "f:query" {"@type" "@json"
                                                "@value" {}}}]}}
             resp (api-post :create {:body    (crypto/create-jws (json/write-value-as-string create-req)
-                                                                (:private auth))
+                                                                (:private root-auth))
                                     :headers jwt-headers})]
         (testing "is accepted"
           (is (= 201 (:status resp))))))
@@ -53,7 +53,7 @@
                           "@context" ["https://ns.flur.ee" default-context]
                           "insert" [{"@id" "ex:coin" "ex:name" "nickel"}]}
             resp (api-post :transact {:body (crypto/create-jws (json/write-value-as-string transact-req)
-                                                               (:private auth))
+                                                               (:private root-auth))
                                       :headers jwt-headers})]
         (testing "is accepted"
           (is (= 200 (:status resp))))))
@@ -63,7 +63,7 @@
                        "where" [{"@id" "?s" "ex:name" "?name"}]
                        "select" "?s"}
             resp (api-post :query {:body (crypto/create-jws (json/write-value-as-string query-req)
-                                                            (:private auth))
+                                                            (:private root-auth))
                                    :headers jwt-headers})]
         (testing "is accepted"
           (is (= 200 (:status resp)))
@@ -75,7 +75,7 @@
                          "history" "ex:coin"
                          "t" {"from" 1 "to" "latest"}}
             resp (api-post :history {:body (crypto/create-jws (json/write-value-as-string history-req)
-                                                              (:private auth))
+                                                              (:private root-auth))
                                      :headers jwt-headers})]
         (testing "is accepted"
           (is (= 200 (:status resp)))
@@ -89,7 +89,7 @@
       (let [create-req {"ledger" "closed-test2"
                         "@context" ["https://ns.flur.ee" default-context]
                         "insert" {"@graph"
-                                  [{"id" (:id auth)
+                                  [{"id" (:id root-auth)
                                     "f:policyClass" {"id" "ex:RootPolicy"}
                                     "type" "schema:Person"
                                     "ex:name" "Root User"}

--- a/test/fluree/server/integration/closed_mode_test.clj
+++ b/test/fluree/server/integration/closed_mode_test.clj
@@ -134,6 +134,19 @@
                                      :headers jwt-headers})]
         (testing "is accepted"
           (is (= 200 (:status resp)))
+          (is (= [] (-> resp :body json/read-value))))))
+    (testing "to claim more authority"
+      (let [create-req {"from" "closed-test"
+                        "@context" default-context
+                        "where" [{"@id" "?s" "ex:name" "?name"}]
+                        "select" ["?s" "?name"]
+                        ;; claiming root-auth identity in opts
+                        "opts" {"did" (:id root-auth)}}
+            resp (api-post :query {:body (crypto/create-jws (json/write-value-as-string create-req)
+                                                            (:private non-root-auth))
+                                   :headers jwt-headers})]
+        (testing "is silently demoted"
+          (is (= 200 (:status resp)))
           (is (= [] (-> resp :body json/read-value)))))))
 
   (testing "unsigned request"

--- a/test/fluree/server/integration/test_system.clj
+++ b/test/fluree/server/integration/test_system.clj
@@ -17,6 +17,10 @@
   {"Content-Type" "application/sparql-query"
    "Accept"       "application/json"})
 
+(def jwt-headers
+  {"Content-Type" "application/jwt"
+   "Accept"       "application/json"})
+
 (defn find-open-port
   ([] (find-open-port nil))
   ([_] ; so it can be used in swap!
@@ -100,3 +104,21 @@
   {:id      "did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh"
    :public  "03b160698617e3b4cd621afd96c0591e33824cb9753ab2f1dace567884b4e242b0"
    :private "509553eece84d5a410f1012e8e19e84e938f226aa3ad144e2d12f36df0f51c1e"})
+
+(defn run-closed-test-server
+  [run-tests]
+  (set-server-ports)
+  (let [config {::config/server     {}
+                ::config/connection {:storage-method :memory
+                                     :parallelism    1
+                                     :cache-max-mb   100}
+                ::config/consensus  {:protocol         :standalone
+                                     :max-pending-txns 16}
+                ::config/http       {:server          :jetty
+                                     :closed-mode     true
+                                     :root-identities [(:id auth)]
+                                     :port            @api-port
+                                     :max-txn-wait-ms 45000}}
+        server (system/start-config config)]
+    (run-tests)
+    (system/stop server)))


### PR DESCRIPTION
https://github.com/fluree/core/issues/112

This adds closed-mode support to server.

There are now two new config keys:
- ["http", "rootIdentities"]: an array of keypair ids
- ["http", "closedMode"]: a boolean flag to enable `closed-mode`

When closed mode is enabled:
- every request is required to be signed
- only a root identity is allowed to create ledgers
- non-root identities are not allowed to claim other identities

In this implementation it is specified that requests from root identities will NOT be called with `wrap-policy`. However, `server` does not call `wrap-policy` on its own, so I've left that for future work.