### PR TITLE
Add policy Fluree-Policy* headers for policy SPARQL

### DIFF
--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -260,10 +260,10 @@
                                                 {:status 400})))))]
       (handler
        (cond-> req
-               policy-identity (assoc :policy/identity policy-identity)
-               policy-class (assoc :policy/class policy-class)
-               policy (assoc :policy/policy policy)
-               policy-values (assoc :policy/values policy-values))))))
+         policy-identity (assoc :policy/identity policy-identity)
+         policy-class (assoc :policy/class policy-class)
+         policy (assoc :policy/policy policy)
+         policy-values (assoc :policy/values policy-values))))))
 
 (defn sort-middleware-by-weight
   [weighted-middleware]

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -245,7 +245,7 @@
           policy          (when-let [p (get-in req [:headers "fluree-policy"])]
                             (try
                               (json/parse p false)
-                              (catch Exception e
+                              (catch Exception _
                                 (throw (ex-info "Invalid policy header, it must be parsable JSON."
                                                 {:status 400})))))
           policy-values   (when-let [pv (get-in req [:headers "fluree-policy-values"])]
@@ -255,7 +255,7 @@
                                   pv*
                                   (throw (ex-info "Invalid policy-values header, it must be a map of variables to values."
                                                   {:status 400}))))
-                              (catch Exception e
+                              (catch Exception _
                                 (throw (ex-info "Invalid policy-values header, it must be parsable JSON."
                                                 {:status 400})))))]
       (handler

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -246,17 +246,17 @@
                             (try
                               (json/parse p false)
                               (catch Exception _
-                                (throw (ex-info "Invalid policy header, it must be parsable JSON."
+                                (throw (ex-info "Invalid Fluree-Policy header: must be JSON."
                                                 {:status 400})))))
           policy-values   (when-let [pv (get-in req [:headers "fluree-policy-values"])]
                             (try
                               (let [pv* (json/parse pv false)]
                                 (if (map? pv*)
                                   pv*
-                                  (throw (ex-info "Invalid policy-values header, it must be a map of variables to values."
+                                  (throw (ex-info "Invalid Fluree-Policy-Values header, it must be a map of variables to values."
                                                   {:status 400}))))
                               (catch Exception _
-                                (throw (ex-info "Invalid policy-values header, it must be parsable JSON."
+                                (throw (ex-info "Invalid Fluree-Policy-Values header: must be JSON."
                                                 {:status 400})))))]
       (handler
        (cond-> req

--- a/src/fluree/server/handlers/ledger.clj
+++ b/src/fluree/server/handlers/ledger.clj
@@ -8,11 +8,11 @@
 (defn add-policy-enforcement-headers
   [override-opts {:keys [credential/did policy/identity policy/class policy/policy policy/values]}]
   (cond-> override-opts
-          identity (assoc :identity identity)
-          did (assoc :identity did) ;; a credential will always override the policy/identity header
-          class (assoc :policy-class class)
-          policy (assoc :policy policy)
-          values (assoc :policy-values values)))
+    identity (assoc :identity identity)
+    did (assoc :identity did) ;; a credential will always override the policy/identity header
+    class (assoc :policy-class class)
+    policy (assoc :policy policy)
+    values (assoc :policy-values values)))
 
 (defhandler query
   [{:keys [fluree/conn] {:keys [body]} :parameters :as req}]

--- a/src/fluree/server/handlers/ledger.clj
+++ b/src/fluree/server/handlers/ledger.clj
@@ -5,27 +5,29 @@
    [fluree.server.handler :as-alias handler]
    [fluree.server.handlers.shared :refer [defhandler deref!]]))
 
+(defn add-policy-enforcement-headers
+  [override-opts {:keys [credential/did policy/identity policy/class policy/policy policy/values]}]
+  (cond-> override-opts
+          identity (assoc :identity identity)
+          did (assoc :identity did) ;; a credential will always override the policy/identity header
+          class (assoc :policy-class class)
+          policy (assoc :policy policy)
+          values (assoc :policy-values values)))
+
 (defhandler query
-  [{:keys [fluree/conn credential/did]
-    {:keys [body]} :parameters}]
-  (let [query  (or (::handler/query body) body)
-        format (or (::handler/format body) :fql)
-        _      (log/debug "query handler received query:" query)
-        opts   (when (= :fql format)
-                 (cond-> (:opts query)
-                   did (assoc :did did)))
-        query* (if opts (assoc query :opts opts) query)]
+  [{:keys [fluree/conn] {:keys [body]} :parameters :as req}]
+  (let [query         (or (::handler/query body) body)
+        format        (or (::handler/format body) :fql)
+        _             (log/debug "query handler received query:" query)
+        override-opts (add-policy-enforcement-headers {:format format} req)]
     {:status 200
-     :body   (deref! (fluree/query-connection conn query* {:format format}))}))
+     :body   (deref! (fluree/query-connection conn query override-opts))}))
 
 (defhandler history
-  [{:keys [fluree/conn credential/did]
-    {{ledger :from :as query} :body} :parameters}]
+  [{:keys [fluree/conn] {{ledger :from :as query} :body} :parameters :as req}]
   (log/debug "history handler got query:" query)
   (let [ledger*       (->> ledger (fluree/load conn) deref!)
-        override-opts (if did
-                        {:identity did}
-                        {})
+        override-opts (add-policy-enforcement-headers {} req)
         query*        (dissoc query :from)
         _             (log/debug "history - Querying ledger" ledger "-" query*)
         results       (deref! (fluree/history ledger* query* override-opts))]

--- a/test/fluree/server/integration/policy_test.clj
+++ b/test/fluree/server/integration/policy_test.clj
@@ -314,8 +314,8 @@
                                         WHERE  {?s a ex:User;
                                                    schema:ssn ?ssn.}")
                          :headers (assoc sparql-headers
-                                    "Fluree-Policy-Class" "ex:EmployeePolicy"
-                                    "Fluree-Policy-Values" (json/write-value-as-string {"?$identity" alice-did}))}
+                                         "Fluree-Policy-Class" "ex:EmployeePolicy"
+                                         "Fluree-Policy-Values" (json/write-value-as-string {"?$identity" alice-did}))}
               query-res (api-post :query query-req)]
 
           (is (= [["ex:alice" "111-11-1111"]]
@@ -382,8 +382,8 @@
           query-req     {:body
                          (json/write-value-as-string
                           (assoc secret-query
-                            "opts" {"policy"       policy
-                                    "policyValues" policy-values}))
+                                 "opts" {"policy"       policy
+                                         "policyValues" policy-values}))
                          :headers json-headers}
           query-res     (api-post :query query-req)]
 
@@ -402,8 +402,8 @@
                                         WHERE  {?s a ex:User;
                                                    schema:ssn ?ssn.}")
                          :headers (assoc sparql-headers
-                                    "Fluree-Policy" (json/write-value-as-string policy)
-                                    "Fluree-Policy-Values" (json/write-value-as-string policy-values))}
+                                         "Fluree-Policy" (json/write-value-as-string policy)
+                                         "Fluree-Policy-Values" (json/write-value-as-string policy-values))}
               query-res (api-post :query query-req)]
 
           (is (= [["ex:alice" "111-11-1111"]]

--- a/test/fluree/server/integration/policy_test.clj
+++ b/test/fluree/server/integration/policy_test.clj
@@ -5,7 +5,7 @@
             [fluree.db.json-ld.credential :as cred]
             [fluree.server.integration.test-system
              :as test-system
-             :refer [api-post auth create-rand-ledger json-headers run-test-server]]
+             :refer [api-post auth create-rand-ledger json-headers sparql-headers run-test-server]]
             [jsonista.core :as json]))
 
 (use-fixtures :once run-test-server)
@@ -304,74 +304,108 @@
 
       (is (= [["ex:alice" "111-11-1111"]]
              (-> query-res :body json/read-value))
-          "query policy opts should prevent seeing john's ssn"))))
+          "query policy opts should prevent seeing john's ssn")
+
+      (testing "same query but with SPARQL and policy headers"
+        (let [query-req {:body    (str "PREFIX schema: <http://schema.org/>
+                                        PREFIX ex: <http://example.org/ns/>
+                                        SELECT ?s ?ssn
+                                        FROM   <" ledger-name ">
+                                        WHERE  {?s a ex:User;
+                                                   schema:ssn ?ssn.}")
+                         :headers (assoc sparql-headers
+                                    "Fluree-Policy-Class" "ex:EmployeePolicy"
+                                    "Fluree-Policy-Values" (json/write-value-as-string {"?$identity" alice-did}))}
+              query-res (api-post :query query-req)]
+
+          (is (= [["ex:alice" "111-11-1111"]]
+                 (-> query-res :body json/read-value))
+              "query policy opts should prevent seeing john's ssn"))))))
 
 (deftest ^:integration ^:json policy-json-ld-opts-test
   (testing "policy-enforcing opts for json-ld policy are correctly handled"
-    (let [ledger-name  (create-rand-ledger "policy-json-ld-opts-test")
-          alice-did    (:id auth)
-          txn-req      {:body
-                        (json/write-value-as-string
-                         {"ledger"   ledger-name
-                          "@context" {"ex"     "http://example.org/ns/"
-                                      "schema" "http://schema.org/"
-                                      "f"      "https://ns.flur.ee/ledger#"}
-                          "insert"   [{"@id"              "ex:alice",
-                                       "@type"            "ex:User",
-                                       "schema:name"      "Alice"
-                                       "schema:email"     "alice@flur.ee"
-                                       "schema:birthDate" "2022-08-17"
-                                       "schema:ssn"       "111-11-1111"}
-                                      {"@id"              "ex:john",
-                                       "@type"            "ex:User",
-                                       "schema:name"      "John"
-                                       "schema:email"     "john@flur.ee"
-                                       "schema:birthDate" "2021-08-17"
-                                       "schema:ssn"       "888-88-8888"}
-                                      {"@id"                  "ex:widget",
-                                       "@type"                "ex:Product",
-                                       "schema:name"          "Widget"
-                                       "schema:price"         99.99
-                                       "schema:priceCurrency" "USD"}
-                                      ;; assign alice-did to "ex:EmployeePolicy" and also link the did to "ex:alice" via "ex:user"
-                                      {"@id"     alice-did
-                                       "ex:user" {"@id" "ex:alice"}}]})
-                        :headers json-headers}
-          txn-res      (api-post :transact txn-req)
-          _            (assert (= 200 (:status txn-res)))
-          secret-query {"@context" {"ex"     "http://example.org/ns/"
-                                    "schema" "http://schema.org/"}
-                        "from"     ledger-name
-                        "select"   ["?s" "?ssn"]
-                        "where"    {"@id"        "?s"
-                                    "@type"      "ex:User"
-                                    "schema:ssn" "?ssn"}}
-          query-req    {:body
-                        (json/write-value-as-string
-                         (assoc secret-query
-                                "opts" {"policy"       {"@context" {"ex"     "http://example.org/ns/"
-                                                                    "schema" "http://schema.org/"
-                                                                    "f"      "https://ns.flur.ee/ledger#"}
-                                                        "@graph"   [{"@id"          "ex:ssnRestriction"
-                                                                     "@type"        ["f:AccessPolicy" "ex:EmployeePolicy"]
-                                                                     "f:onProperty" [{"@id" "schema:ssn"}]
-                                                                     "f:action"     [{"@id" "f:view"} {"@id" "f:modify"}]
-                                                                     "f:query"      {"@type"  "@json"
-                                                                                     "@value" {"@context" {"ex" "http://example.org/ns/"}
-                                                                                               "where"    {"@id"     "?$identity"
-                                                                                                           "ex:user" {"@id" "?$this"}}}}}
-                                                                    {"@id"      "ex:defaultAllowView"
-                                                                     "@type"    ["f:AccessPolicy" "ex:EmployeePolicy"]
-                                                                     "f:action" {"@id" "f:view"}
-                                                                     "f:query"  {"@type"  "@json"
-                                                                                 "@value" {}}}]}
-                                        "policyValues" {"?$identity" alice-did}}))
-                        :headers json-headers}
-          query-res    (api-post :query query-req)]
+    (let [ledger-name   (create-rand-ledger "policy-json-ld-opts-test")
+          alice-did     (:id auth)
+          txn-req       {:body
+                         (json/write-value-as-string
+                          {"ledger"   ledger-name
+                           "@context" {"ex"     "http://example.org/ns/"
+                                       "schema" "http://schema.org/"
+                                       "f"      "https://ns.flur.ee/ledger#"}
+                           "insert"   [{"@id"              "ex:alice",
+                                        "@type"            "ex:User",
+                                        "schema:name"      "Alice"
+                                        "schema:email"     "alice@flur.ee"
+                                        "schema:birthDate" "2022-08-17"
+                                        "schema:ssn"       "111-11-1111"}
+                                       {"@id"              "ex:john",
+                                        "@type"            "ex:User",
+                                        "schema:name"      "John"
+                                        "schema:email"     "john@flur.ee"
+                                        "schema:birthDate" "2021-08-17"
+                                        "schema:ssn"       "888-88-8888"}
+                                       {"@id"                  "ex:widget",
+                                        "@type"                "ex:Product",
+                                        "schema:name"          "Widget"
+                                        "schema:price"         99.99
+                                        "schema:priceCurrency" "USD"}
+                                       ;; assign alice-did to "ex:EmployeePolicy" and also link the did to "ex:alice" via "ex:user"
+                                       {"@id"     alice-did
+                                        "ex:user" {"@id" "ex:alice"}}]})
+                         :headers json-headers}
+          txn-res       (api-post :transact txn-req)
+          _             (assert (= 200 (:status txn-res)))
+          secret-query  {"@context" {"ex"     "http://example.org/ns/"
+                                     "schema" "http://schema.org/"}
+                         "from"     ledger-name
+                         "select"   ["?s" "?ssn"]
+                         "where"    {"@id"        "?s"
+                                     "@type"      "ex:User"
+                                     "schema:ssn" "?ssn"}}
+          policy        {"@context" {"ex"     "http://example.org/ns/"
+                                     "schema" "http://schema.org/"
+                                     "f"      "https://ns.flur.ee/ledger#"}
+                         "@graph"   [{"@id"          "ex:ssnRestriction"
+                                      "@type"        ["f:AccessPolicy" "ex:EmployeePolicy"]
+                                      "f:onProperty" [{"@id" "schema:ssn"}]
+                                      "f:action"     [{"@id" "f:view"} {"@id" "f:modify"}]
+                                      "f:query"      {"@type"  "@json"
+                                                      "@value" {"@context" {"ex" "http://example.org/ns/"}
+                                                                "where"    {"@id"     "?$identity"
+                                                                            "ex:user" {"@id" "?$this"}}}}}
+                                     {"@id"      "ex:defaultAllowView"
+                                      "@type"    ["f:AccessPolicy" "ex:EmployeePolicy"]
+                                      "f:action" {"@id" "f:view"}
+                                      "f:query"  {"@type"  "@json"
+                                                  "@value" {}}}]}
+          policy-values {"?$identity" alice-did}
+          query-req     {:body
+                         (json/write-value-as-string
+                          (assoc secret-query
+                            "opts" {"policy"       policy
+                                    "policyValues" policy-values}))
+                         :headers json-headers}
+          query-res     (api-post :query query-req)]
 
       (is (= 200 (:status query-res))
           (str "policy-enforced query response was: " (pr-str query-res)))
 
       (is (= [["ex:alice" "111-11-1111"]]
              (-> query-res :body json/read-value))
-          "query policy opts should prevent seeing john's ssn"))))
+          "query policy opts should prevent seeing john's ssn")
+
+      (testing "Same query but in SPARQL with policy http headers"
+        (let [query-req {:body    (str "PREFIX schema: <http://schema.org/>
+                                        PREFIX ex: <http://example.org/ns/>
+                                        SELECT ?s ?ssn
+                                        FROM   <" ledger-name ">
+                                        WHERE  {?s a ex:User;
+                                                   schema:ssn ?ssn.}")
+                         :headers (assoc sparql-headers
+                                    "Fluree-Policy" (json/write-value-as-string policy)
+                                    "Fluree-Policy-Values" (json/write-value-as-string policy-values))}
+              query-res (api-post :query query-req)]
+
+          (is (= [["ex:alice" "111-11-1111"]]
+                 (-> query-res :body json/read-value))
+              "query policy opts should prevent seeing john's ssn"))))))


### PR DESCRIPTION
Adds support for 4 new HTTP headers to control policy.

These are here primarily for SPARQL queries which don't have an `opts` map where we can define policy-related items.

The headers added, along with their equivalent `:opts` map keys are:
`Fluree-Policy-Class` -> `:policy-class`
`Fluree-Policy-Identity` -> `:identity`
`Fluree-Policy-Values` -> `:policy-values` (stringified JSON)
`Fluree-Policy` -> `:policy` (stringified JSON)

*Note these will be overridden by a signed credential request.

Tests are included for all of these headers.