### PR TITLE
Update dockerfile java opts2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,12 @@ RUN groupadd --gid ${USER_GID} ${USER_NAME} && \
 USER ${USER_NAME}
 
 COPY --from=builder --chown=${USER_NAME}:${USER_NAME} /usr/src/fluree-server/target/server-*.jar ./server.jar
+COPY entrypoint.sh /
 
 EXPOSE 8090
 EXPOSE 58090
 
 VOLUME ./data
 
-ENTRYPOINT ["java", "-jar", "server.jar"]
+ENTRYPOINT ["/entrypoint.sh", "-jar", "server.jar"]
 CMD ["--profile=docker"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ARG USER_NAME=fluree
 ARG USER_UID=10001
 ARG USER_GID=${USER_UID}
 ENV FLUREE_HOME=/opt/fluree-server
+ENV JAVA_OPTS="-Xmx8g"
 
 WORKDIR ${FLUREE_HOME}
 
@@ -39,5 +40,5 @@ EXPOSE 58090
 
 VOLUME ./data
 
-ENTRYPOINT ["java", "-Xmx8g", "-jar", "server.jar"]
+ENTRYPOINT ["java", "-jar", "server.jar"]
 CMD ["--profile=docker"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#! /bin/sh 
+
+exec java $JAVA_OPTS "$@"


### PR DESCRIPTION
Add entrypoint.sh to add JAVA_OPTS when starting java process
```
(base) 10:36 ➜  server $ docker run -it -e JAVA_OPTS="-Xmx4g" --entrypoint "/entrypoint.sh" fluree/server:local -cp server.jar clojure.main
Clojure 1.11.3
user=> (let [runtime (Runtime/getRuntime)]
    {:max-memory (/ (.maxMemory runtime) (* 1024 1024))
     :total-memory (/ (.totalMemory runtime) (* 1024 1024))
     :free-memory (/ (.freeMemory runtime) (* 1024 1024))})
{:max-memory 4096, :total-memory 632, :free-memory 38916535/65536}
user=>
(base) 10:38 ➜  server $ docker run -it --entrypoint "/entrypoint.sh" fluree/server:local -cp server.jar clojure.main
Clojure 1.11.3
user=> (let [runtime (Runtime/getRuntime)]
    {:max-memory (/ (.maxMemory runtime) (* 1024 1024))
     :total-memory (/ (.totalMemory runtime) (* 1024 1024))
     :free-memory (/ (.freeMemory runtime) (* 1024 1024))})
{:max-memory 8192, :total-memory 636, :free-memory 1211209/2048}
user=>
```