### PR TITLE
Unblock transaction queue in the case of errors

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "9dbd8accb6ee9160bca5d4848c99e52f71793b89"}
+                                :git/sha "0610cf67c487e22fe246ad113bd950baa066bbf9"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 


### PR DESCRIPTION
Previously an error while processing an event message sent to the transaction queue would attempt to put a `nil` value on the transaction queue's output channel, which generated an uncaught exception that would effectively block the transaction queue from processing further messages. 

This patch detects error/`nil` values while processing events and prevents those values from going to the output channel so that subsequent events can still be processed.