### PR TITLE
Feature/sparql protocol query

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "de63ab3e47a53bce0bb4b038487f91c57cfab580"}
+                                :git/sha "e9973020225f87419bed057c5c45ac09be92427f"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "e9973020225f87419bed057c5c45ac09be92427f"}
+                                :git/sha "e345dd96fa0b7641e7dd93a9333484a5b590ed8f"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -251,17 +251,20 @@
           fuel 1000] ; TODO: get this for real
       (assoc-in resp [:headers "x-fdb-fuel"] (str fuel)))))
 
+(def fluree-header-opts
+  ["fluree-meta" "fluree-max-fuel" "fluree-identity" "fluree-policy-identity"
+   "fluree-policy" "fluree-policy-class" "fluree-policy-values"
+   "fluree-format" "fluree-output"])
+
 (defn wrap-header-opts
   "Extract options from headers, parse and validate them where necessary, and attach to
   request. Opts set in the header override those specified within the transaction or
-  query. Intended mainly to provide a method of specifying opts for SPARQL queries"
+  query."
   [handler]
   (fn [{:keys [headers credential/did] :as req}]
     (let [{:keys [meta max-fuel identity policy-identity policy policy-class policy-values format output]}
           (-> headers
-              (select-keys ["fluree-meta" "fluree-max-fuel" "fluree-identity" "fluree-policy-identity"
-                            "fluree-policy" "fluree-policy-class" "fluree-policy-values"
-                            "fluree-format" "fluree-output"])
+              (select-keys fluree-header-opts)
               (update-keys (fn [k] (keyword (subs k (count "fluree-"))))))
 
           meta     (when meta

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -1,5 +1,6 @@
 (ns fluree.server.handler
   (:require [clojure.core.async :as async :refer [<!!]]
+            [clojure.string :as str]
             [fluree.db.json-ld.credential :as cred]
             [fluree.db.query.fql.syntax :as fql]
             [fluree.db.query.history.parse :as fqh]
@@ -264,7 +265,7 @@
               (update-keys (fn [k] (keyword (subs k (count "fluree-"))))))
 
           meta     (when meta
-                     (case meta
+                     (case (str/lower-case meta)
                        "false" false
                        "true"  true
                        (throw (ex-info "Invalid Fluree-Meta header: must be boolean."

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -86,7 +86,8 @@
 (def QueryResponse
   (m/schema [:orn
              [:select [:sequential [:or coll? map?]]]
-             [:select-one [:or coll? map?]]]))
+             [:select-one [:or coll? map?]]
+             [:construct map?]]))
 
 (def HistoryQuery
   (m/schema (fqh/history-query-schema [[:from LedgerAlias]])

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -249,38 +249,74 @@
           fuel 1000] ; TODO: get this for real
       (assoc-in resp [:headers "x-fdb-fuel"] (str fuel)))))
 
-(defn wrap-policy-metadata
-  "Both Fluree-Policy-Class and Fluree-Policy-Identity can be optionally
-  set in the header for non-credentialed queries/transactions. The primary
-  motivation is enforcing policy with SPARQL which doesn't have an opts
-  map option, although if set, it will also override policyClass/Identity
-  that might have otherwise been set in FlureeQL/JSON."
+(defn wrap-header-opts
+  "Extract options from headers, parse and validate them where necessary, and attach to
+  request. Opts set in the header override those specified within the transaction or
+  query. Intended mainly to provide a method of specifying opts for SPARQL queries"
   [handler]
-  (fn [req]
-    (let [policy-identity (get-in req [:headers "fluree-policy-identity"])
-          policy-class    (get-in req [:headers "fluree-policy-class"])
-          policy          (when-let [p (get-in req [:headers "fluree-policy"])]
-                            (try
-                              (json/parse p false)
-                              (catch Exception _
-                                (throw (ex-info "Invalid Fluree-Policy header: must be JSON."
-                                                {:status 400})))))
-          policy-values   (when-let [pv (get-in req [:headers "fluree-policy-values"])]
-                            (try
-                              (let [pv* (json/parse pv false)]
-                                (if (sequential? pv*)
-                                  pv*
-                                  (throw (ex-info "Invalid Fluree-Policy-Values header, it must be a valid values binding: [[\"?varA\" \"?varB\"] [[<a1> <b1>] [<a2> <b2>] ...]]"
-                                                  {:status 400}))))
-                              (catch Exception _
-                                (throw (ex-info "Invalid Fluree-Policy-Values header: must be JSON."
-                                                {:status 400})))))]
-      (handler
-       (cond-> req
-         policy-identity (assoc :policy/identity policy-identity)
-         policy-class (assoc :policy/class policy-class)
-         policy (assoc :policy/policy policy)
-         policy-values (assoc :policy/values policy-values))))))
+  (fn [{:keys [headers credential/did] :as req}]
+    (let [{:keys [meta max-fuel identity policy-identity policy policy-class policy-values format output]}
+          (-> headers
+              (select-keys ["fluree-meta" "fluree-max-fuel" "fluree-identity" "fluree-policy-identity"
+                            "fluree-policy" "fluree-policy-class" "fluree-policy-values"
+                            "fluree-format" "fluree-output"])
+              (update-keys (fn [k] (keyword (subs k (count "fluree-"))))))
+
+          meta     (when meta
+                     (case meta
+                       "false" false
+                       "true"  true
+                       (throw (ex-info "Invalid Fluree-Meta header: must be boolean."
+                                       {:status 400}))))
+          max-fuel (when max-fuel
+                     (try (Integer/parseInt max-fuel)
+                          (catch Exception _
+                            (throw (ex-info "Invalid Fluree-Max-Fuel header: must be integer."
+                                            {:status 400})))))
+          ;; Accept header takes precedence over other ways of specifying query output
+          output   (cond (-> headers (get "accept") (= "application/sparql-results+json"))
+                         :sparql
+
+                         (= output "sparql") :sparql
+                         (= output "fql")    :fql
+                         :else               :fql)
+          ;; Content-Type header takes precedence over other ways of specifying query format
+          format        (cond (-> headers (get "content-type") (= "application/sparql-query"))
+                              :sparql
+
+                              (= format "sparql") :sparql
+                              (= output "fql")    :fql
+                              :else               :fql)
+          policy        (when policy
+                          (try (json/parse policy false)
+                               (catch Exception _
+                                 (throw (ex-info "Invalid Fluree-Policy header: must be JSON."
+                                                 {:status 400})))))
+          policy-values (when policy-values
+                          (try (let [pv (json/parse policy-values false)]
+                                 (if (sequential? pv)
+                                   pv
+                                   (throw (ex-info "Invalid Fluree-Policy-Values header, it must be a valid values binding: [[\"?varA\" \"?varB\"] [[<a1> <b1>] [<a2> <b2>] ...]]"
+                                                   {:status 400}))))
+                               (catch Exception _
+                                 (throw (ex-info "Invalid Fluree-Policy-Values header: must be JSON."
+                                                 {:status 400})))))
+
+          opts (cond-> {}
+                 meta            (assoc :meta meta)
+                 max-fuel        (assoc :max-fuel max-fuel)
+                 format          (assoc :format format)
+                 output          (assoc :output output)
+                 policy          (assoc :policy policy)
+                 policy-class    (assoc :policy-class policy-class)
+                 policy-values   (assoc :policy-values policy-values)
+
+                 policy-identity (assoc :identity identity)
+                 ;; Fluree-Identity overrides Fluree-Policy-Identity
+                 identity        (assoc :identity identity)
+                 ;; credential (signed) identity overrides all else
+                 did             (assoc :identity did))]
+      (handler (assoc req :fluree/opts opts)))))
 
 (defn sort-middleware-by-weight
   [weighted-middleware]
@@ -356,7 +392,7 @@
                                 [200 coercion/coerce-exceptions-middleware]
                                 [300 coercion/coerce-response-middleware]
                                 [400 coercion/coerce-request-middleware]
-                                [500 wrap-policy-metadata]
+                                [500 wrap-header-opts]
                                 [600 (wrap-closed-mode root-identities closed-mode)]
                                 [1000 exception-middleware]])))
 

--- a/src/fluree/server/handlers/ledger.clj
+++ b/src/fluree/server/handlers/ledger.clj
@@ -5,33 +5,18 @@
    [fluree.server.handler :as-alias handler]
    [fluree.server.handlers.shared :refer [defhandler deref!]]))
 
-(defn add-policy-enforcement-headers
-  [override-opts {:keys [credential/did policy/identity policy/class policy/policy policy/values]}]
-  (cond-> override-opts
-    identity (assoc :identity identity)
-    did (assoc :identity did) ;; a credential will always override the policy/identity header
-    class (assoc :policy-class class)
-    policy (assoc :policy policy)
-    values (assoc :policy-values values)))
-
 (defhandler query
-  [{:keys [fluree/conn] {:keys [body]} :parameters :as req}]
-  (let [query         (or (::handler/query body) body)
-        format        (or (::handler/format body) :fql)
-        output        (if (-> req :headers (get "accept") (= "application/sparql-results+json")) :sparql :fql)
-        _             (log/debug "query handler received query:" query)
-        override-opts (add-policy-enforcement-headers {:format format :output output} req)]
+  [{:keys [fluree/conn fluree/opts] {:keys [body]} :parameters :as _req}]
+  (let [query (or (::handler/query body) body)]
+    (log/debug "query handler received query:" query opts)
     {:status 200
-     :body   (deref! (fluree/query-connection conn query override-opts))}))
+     :body   (deref! (fluree/query-connection conn query opts))}))
 
 (defhandler history
-  [{:keys [fluree/conn] {{ledger :from :as query} :body} :parameters :as req}]
-  (log/debug "history handler got query:" query)
+  [{:keys [fluree/conn fluree/opts] {{ledger :from :as query} :body} :parameters :as _req}]
+
   (let [ledger*       (->> ledger (fluree/load conn) deref!)
-        override-opts (add-policy-enforcement-headers {} req)
-        query*        (dissoc query :from)
-        _             (log/debug "history - Querying ledger" ledger "-" query*)
-        results       (deref! (fluree/history ledger* query* override-opts))]
-    (log/debug "history - query results:" results)
+        query*        (dissoc query :from)]
+    (log/debug "history handler received query:" query opts)
     {:status 200
-     :body   results}))
+     :body   (deref! (fluree/history ledger* query* opts))}))

--- a/src/fluree/server/handlers/ledger.clj
+++ b/src/fluree/server/handlers/ledger.clj
@@ -18,8 +18,9 @@
   [{:keys [fluree/conn] {:keys [body]} :parameters :as req}]
   (let [query         (or (::handler/query body) body)
         format        (or (::handler/format body) :fql)
+        output        (if (-> req :headers (get "accept") (= "application/sparql-results+json")) :sparql :fql)
         _             (log/debug "query handler received query:" query)
-        override-opts (add-policy-enforcement-headers {:format format} req)]
+        override-opts (add-policy-enforcement-headers {:format format :output output} req)]
     {:status 200
      :body   (deref! (fluree/query-connection conn query override-opts))}))
 

--- a/test/fluree/server/integration/sparql_test.clj
+++ b/test/fluree/server/integration/sparql_test.clj
@@ -26,12 +26,25 @@
                                       WHERE  {?test a schema:Test;
                                                     ex:name ?name.}")
           query-res   (api-post :query {:body    query
-                                        :headers sparql-results-headers})]
+                                        :headers sparql-results-headers})
+
+          meta-res    (api-post :query {:body    query
+                                        :headers (assoc sparql-results-headers
+                                                        "Fluree-Meta" true)})]
 
       (is (= 200 (:status query-res)))
-
       (is (= {"head" {"vars" ["name"]}
               "results"
               {"bindings"
                [{"name" {"value" "query-sparql-test", "type" "literal"}}]}}
-             (-> query-res :body json/read-value))))))
+             (-> query-res :body json/read-value)))
+
+      (is (= 200 (:status meta-res)))
+      (is (= {"fuel" 2,
+              "status" 200,
+              "result"
+              {"results"
+               {"bindings"
+                [{"name" {"value" "query-sparql-test", "type" "literal"}}]},
+               "head" {"vars" ["name"]}}}
+             (-> meta-res :body json/read-value (dissoc "time")))))))

--- a/test/fluree/server/integration/sparql_test.clj
+++ b/test/fluree/server/integration/sparql_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [fluree.server.integration.test-system
              :refer [api-post create-rand-ledger json-headers run-test-server
-                     sparql-headers]]
+                     sparql-results-headers]]
             [jsonista.core :as json]))
 
 (use-fixtures :once run-test-server)
@@ -10,27 +10,28 @@
 (deftest ^:integration ^:sparql query-sparql-test
   (testing "basic SPARQL query works"
     (let [ledger-name (create-rand-ledger "query-sparql-test")
-          txn-req     {:body
-                       (json/write-value-as-string
-                        {"ledger"   ledger-name
-                         "@context" {"schema" "http://schema.org/"
-                                     "ex"     "http://example.org/"}
-                         "insert"   [{"@id"     "ex:query-sparql-test"
-                                      "@type"   "schema:Test"
-                                      "ex:name" "query-sparql-test"}]})
-                       :headers json-headers}
-          txn-res     (api-post :transact txn-req)
+          txn         {"ledger"   ledger-name
+                       "@context" {"schema" "http://schema.org/"
+                                   "ex"     "http://example.org/"}
+                       "insert"   [{"@id"     "ex:query-sparql-test"
+                                    "@type"   "schema:Test"
+                                    "ex:name" "query-sparql-test"}]}
+          txn-res     (api-post :transact {:body    (json/write-value-as-string txn)
+                                           :headers json-headers})
           _           (assert (= 200 (:status txn-res)))
-          query-req   {:body    (str "PREFIX schema: <http://schema.org/>
+          query       (str "PREFIX schema: <http://schema.org/>
                                       PREFIX ex: <http://example.org/>
                                       SELECT ?name
                                       FROM   <" ledger-name ">
                                       WHERE  {?test a schema:Test;
                                                     ex:name ?name.}")
-                       :headers sparql-headers}
-          query-res   (api-post :query query-req)]
+          query-res   (api-post :query {:body    query
+                                        :headers sparql-results-headers})]
 
       (is (= 200 (:status query-res)))
 
-      (is (= [["query-sparql-test"]]
+      (is (= {"head" {"vars" ["name"]}
+              "results"
+              {"bindings"
+               [{"name" {"value" "query-sparql-test", "type" "literal"}}]}}
              (-> query-res :body json/read-value))))))

--- a/test/fluree/server/integration/test_system.clj
+++ b/test/fluree/server/integration/test_system.clj
@@ -17,6 +17,10 @@
   {"Content-Type" "application/sparql-query"
    "Accept"       "application/json"})
 
+(def sparql-results-headers
+  {"Content-Type" "application/sparql-query"
+   "Accept"       "application/sparql-results+json"})
+
 (def jwt-headers
   {"Content-Type" "application/jwt"
    "Accept"       "application/json"})


### PR DESCRIPTION
This adds support for `Accept: application/sparql-results+json` headers, making our `fluree/query` endpoint a SPARQL Protocol compliant endpoint. 

I also added support for all query opts being specified as http headers in order to bring feature parity to SPARQL queries. Options specified in headers take precedence over those specified in the query body for FQL.

Related to https://github.com/fluree/core/issues/170