### PR TITLE
Latest fluree/db, no need for 'prepare'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/fluree-server
 
 COPY deps.edn ./
 
-RUN clojure -X:deps prep && clojure -P && clojure -A:build:test -P
+RUN clojure -P && clojure -A:build:test -P
 
 COPY . ./
 

--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,13 @@ RESOURCES := $(shell find resources)
 help: ## Describe available tasks
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-target/server-%.jar: $(SOURCES) $(RESOURCES) prepare
+target/server-%.jar: $(SOURCES) $(RESOURCES)
 	clojure -T:build uber
 
 .PHONY: uberjar
 uberjar: target/server-%.jar ## Build an executable server uberjar
 
 .DEFAULT_GOAL := uberjar
-
-.PHONY: prepare
-prepare: ## Prepare library dependencies
-	clojure -X:deps prep
 
 .PHONY: docker-build
 docker-build: ## Build the server docker container
@@ -30,30 +26,30 @@ docker-push: ## Build and publish the server docker container
 	docker buildx build --platform linux/amd64,linux/arm64 -t fluree/server:latest -t fluree/server:$(shell git rev-parse HEAD) --build-arg="PROFILE=prod" --push .
 
 .PHONY: test
-test: prepare ## Run tests
+test: ## Run tests
 	clojure -X:test
 
 .PHONY: benchmark
-benchmark: prepare ## Benchmark performance
+benchmark: ## Benchmark performance
 	clojure -X:benchmark
 
 .PHONY: pending-tests
-pending-tests: prepare ## Run pending tests
+pending-tests: ## Run pending tests
 	clojure -X:pending-tests
 
 .PHONY: pt
 pt: pending-tests
 
 .PHONY: clj-kondo-lint
-clj-kondo-lint: prepare ## Lint Clojure code with clj-kondo
+clj-kondo-lint: ## Lint Clojure code with clj-kondo
 	clj-kondo --lint src:test:build.clj
 
 .PHONY: clj-kondo-lint-ci
-clj-kondo-lint-ci: prepare
+clj-kondo-lint-ci:
 	clj-kondo --lint src:test:build.clj --config .clj-kondo/ci-config.edn
 
 .PHONY: cljfmt-check
-cljfmt-check: prepare ## Check Clojure formatting with cljfmt
+cljfmt-check: ## Check Clojure formatting with cljfmt
 	cljfmt check src test build.clj
 
 .PHONY: clean

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "0610cf67c487e22fe246ad113bd950baa066bbf9"}
+                                :git/sha "32b5966bd40a5bfdf9e7f12eb0d6171ead88dc69"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 


### PR DESCRIPTION
This removes the 'prepare' steps in the makefile, as with the latest db it is no longer needed.

Updates to latest fluree/db:main
