### PR TITLE
Separate broadcast and watcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,13 @@ RESOURCES := $(shell find resources)
 help: ## Describe available tasks
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
-target/server-%.jar: $(SOURCES) $(RESOURCES) prepare
+target/server-%.jar: $(SOURCES) $(RESOURCES)
 	clojure -T:build uber
 
 .PHONY: uberjar
 uberjar: target/server-%.jar ## Build an executable server uberjar
 
 .DEFAULT_GOAL := uberjar
-
-.PHONY: prepare
-prepare: ## Prepare library dependencies
-	clojure -X:deps prep
 
 .PHONY: docker-build
 docker-build: ## Build the server docker container
@@ -30,22 +26,22 @@ docker-push: ## Build and publish the server docker container
 	docker buildx build --platform linux/amd64,linux/arm64 -t fluree/server:latest -t fluree/server:$(shell git rev-parse HEAD) --build-arg="PROFILE=prod" --push .
 
 .PHONY: test
-test: prepare ## Run tests
+test: ## Run tests
 	clojure -X:test
 
 .PHONY: benchmark
-benchmark: prepare ## Benchmark performance
+benchmark: ## Benchmark performance
 	clojure -X:benchmark
 
 .PHONY: pending-tests
-pending-tests: prepare ## Run pending tests
+pending-tests: ## Run pending tests
 	clojure -X:pending-tests
 
 .PHONY: pt
 pt: pending-tests
 
 .PHONY: clj-kondo-lint
-clj-kondo-lint: prepare ## Lint Clojure code with clj-kondo
+clj-kondo-lint: ## Lint Clojure code with clj-kondo
 	clj-kondo --lint src:test:build.clj
 
 .PHONY: clj-kondo-lint-ci
@@ -53,7 +49,7 @@ clj-kondo-lint-ci: prepare
 	clj-kondo --lint src:test:build.clj --config .clj-kondo/ci-config.edn
 
 .PHONY: cljfmt-check
-cljfmt-check: prepare ## Check Clojure formatting with cljfmt
+cljfmt-check: ## Check Clojure formatting with cljfmt
 	cljfmt check src test build.clj
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ clj-kondo-lint: ## Lint Clojure code with clj-kondo
 	clj-kondo --lint src:test:build.clj
 
 .PHONY: clj-kondo-lint-ci
-clj-kondo-lint-ci: prepare
+clj-kondo-lint-ci:
 	clj-kondo --lint src:test:build.clj --config .clj-kondo/ci-config.edn
 
 .PHONY: cljfmt-check

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "89a58a88185d30eaebd838c83dba12517d3f449c"}
+                                :git/sha "c603a4e0c8307c102ce38ef8736e95eb945bb19a"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "c603a4e0c8307c102ce38ef8736e95eb945bb19a"}
+                                :git/sha "4dd9dfcf2c202680314c7ac7cc8d76cde6bd3973"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "146eb095528d7fc1e70f1f7f0b4a65f339378f59"}
+                                :git/sha "4fc257327030389cb6f2fedca1c5641ffc3c086f"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "177af4631b772655d87c57d1eb4d7a657f3c0f19"}
+                                :git/sha "52c7505b699cbd6ee91d73514471f24636a2882d"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "4fc257327030389cb6f2fedca1c5641ffc3c086f"}
+                                :git/sha "de63ab3e47a53bce0bb4b038487f91c57cfab580"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "0610cf67c487e22fe246ad113bd950baa066bbf9"}
+                                :git/sha "177af4631b772655d87c57d1eb4d7a657f3c0f19"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "52c7505b699cbd6ee91d73514471f24636a2882d"}
+                                :git/sha "89a58a88185d30eaebd838c83dba12517d3f449c"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 

--- a/src/fluree/server.clj
+++ b/src/fluree/server.clj
@@ -1,97 +1,28 @@
 (ns fluree.server
-  (:require [clojure.string :as str]
-            [clojure.tools.cli :as cli]
-            [fluree.db.util.log :as log]
+  (:require [fluree.db.util.log :as log]
+            [fluree.server.command :as command]
             [fluree.server.system :as system])
   (:gen-class))
 
 (set! *warn-on-reflection* true)
 
-(defn strip-leading-colon
-  [s]
-  (if (str/starts-with? s ":")
-    (subs s 1)
-    s))
-
-(defn profile-string->keyword
-  [s]
-  (-> s str/trim strip-leading-colon keyword))
-
-(def cli-options
-  [["-p" "--profile PROFILE" "Run profile"
-    :default  :prod
-    :parse-fn profile-string->keyword]
-   ["-c" "--config FILE" "Load configuration at a file path"]
-   ["-s" "--string STRING" "Load stringified configuration"]
-   ["-r" "--resource NAME" "Load pre-defined configuration resource"]
-   ["-h" "--help" "Print this usage summary and exit"]])
-
-(defn single-configuration?
-  [{:keys [config string resource]}]
-  (->> [config string resource] (remove nil?) count (>= 1)))
-
-(def multiple-configuration-error
-  (str "Only a single configuration option from"
-       "-c/--config, -s/--string, and -r/--resource"
-       "is allowed."))
-
-(defn validate-opts
-  [{:keys [options] :as parsed-opts}]
-  (if (single-configuration? options)
-    parsed-opts
-    (update parsed-opts :errors conj multiple-configuration-error)))
-
-(defn parse-cli
-  [args]
-  (-> args
-      (cli/parse-opts cli-options)
-      validate-opts))
-
-(defn usage
-  [summary]
-  (str/join \newline ["Fluree Ledger Server"
-                      ""
-                      "Options:"
-                      summary]))
-
-(defn error-message
-  [errors]
-  (str/join \newline errors))
-
-(defn exit
-  [status message]
-  (println message)
-  (System/exit status))
-
 (defn start
-  [{:keys [profile] :as options}]
-  (if-let [config-string (:string options)]
-    (do (log/info "Starting Fluree server from command line configuration with profile:"
-                  profile)
-        (system/start-config config-string profile))
-    (if-let [config-path (:config options)]
-      (do (log/info "Starting Fluree server configuration at path:" config-path
-                    "with profile:" profile)
-          (system/start-file config-path profile))
-      (if-let [config-resource (:resource options)]
-        (do (log/info "Starting Fluree server configuration from resource:" config-resource)
-            (system/start-resource config-resource profile))
-        (do (log/info "Starting Fluree server with profile:" profile)
-            (system/start profile))))))
-
-(defn run
-  [{:keys [options errors summary]}]
-  (cond (seq errors)
-        (let [msg (error-message errors)]
-          (exit 1 msg))
-
-        (:help options)
-        (let [msg (usage summary)]
-          (exit 0 msg))
-
-        :else
-        (start options)))
+  [{:keys [options] :as _cli}]
+  (let [{:keys [profile]} options]
+    (if-let [config-string (:string options)]
+      (do (log/info "Starting Fluree server from command line configuration with profile:"
+                    profile)
+          (system/start-config config-string profile))
+      (if-let [config-path (:config options)]
+        (do (log/info "Starting Fluree server configuration at path:" config-path
+                      "with profile:" profile)
+            (system/start-file config-path profile))
+        (if-let [config-resource (:resource options)]
+          (do (log/info "Starting Fluree server configuration from resource:" config-resource)
+              (system/start-resource config-resource profile))
+          (do (log/info "Starting Fluree server with profile:" profile)
+              (system/start profile)))))))
 
 (defn -main
   [& args]
-  (-> args parse-cli run))
+  (-> args command/formulate start))

--- a/src/fluree/server/broadcast.clj
+++ b/src/fluree/server/broadcast.clj
@@ -1,4 +1,5 @@
-(ns fluree.server.broadcast)
+(ns fluree.server.broadcast
+  (:require [fluree.server.consensus.events :as events]))
 
 (set! *warn-on-reflection* true)
 
@@ -20,3 +21,10 @@
   [broadcaster {:keys [ledger-id] :as error-event}]
   (-broadcast-error broadcaster ledger-id error-event)
   ::error)
+
+(defn broadcast-event!
+  [broadcaster result]
+  (case (events/event-type result)
+    :transaction-committed (broadcast-new-commit! broadcaster result)
+    :ledger-created        (broadcast-new-ledger! broadcaster result)
+    :error                 (broadcast-error! broadcaster result)))

--- a/src/fluree/server/broadcast.clj
+++ b/src/fluree/server/broadcast.clj
@@ -1,7 +1,7 @@
 (ns fluree.server.broadcast
   (:require [fluree.db.util.log :as log]
             [fluree.server.consensus.events :as events]
-            [fluree.server.consensus.watcher :as watcher]))
+            [fluree.server.watcher :as watcher]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/fluree/server/broadcast.clj
+++ b/src/fluree/server/broadcast.clj
@@ -14,7 +14,7 @@
         (events/ledger-created new-ledger-params new-ledger-result)]
     (log/info (str "New Ledger successfully created by server " server
                    ": " ledger-id " with tx-id: " tx-id "."))
-    (watcher/deliver-commit watcher tx-id ledger-created-event)
+    (watcher/deliver-commit watcher ledger-created-event)
     (-broadcast broadcaster ledger-id ledger-created-event)
     ::new-ledger))
 
@@ -24,7 +24,7 @@
         (events/transaction-committed commit-params commit-result)]
     (log/info "New transaction completed for" ledger-id
               "tx-id: " tx-id "by server:" server)
-    (watcher/deliver-commit watcher tx-id transaction-committed-event)
+    (watcher/deliver-commit watcher transaction-committed-event)
     (-broadcast broadcaster ledger-id transaction-committed-event)
     ::new-commit))
 

--- a/src/fluree/server/broadcast.clj
+++ b/src/fluree/server/broadcast.clj
@@ -1,5 +1,4 @@
-(ns fluree.server.broadcast
-  (:require [fluree.db.util.log :as log]))
+(ns fluree.server.broadcast)
 
 (set! *warn-on-reflection* true)
 

--- a/src/fluree/server/broadcast.clj
+++ b/src/fluree/server/broadcast.clj
@@ -3,19 +3,20 @@
 (set! *warn-on-reflection* true)
 
 (defprotocol Broadcaster
-  (-broadcast [b ledger-id event]))
+  (-broadcast-commit [b ledger-id event])
+  (-broadcast-error [b ledger-id error-event]))
 
 (defn broadcast-new-ledger!
   [broadcaster {:keys [ledger-id] :as ledger-created-event}]
-  (-broadcast broadcaster ledger-id ledger-created-event)
+  (-broadcast-commit broadcaster ledger-id ledger-created-event)
   ::new-ledger)
 
 (defn broadcast-new-commit!
   [broadcaster {:keys [ledger-id] :as transaction-committed-event}]
-  (-broadcast broadcaster ledger-id transaction-committed-event)
+  (-broadcast-commit broadcaster ledger-id transaction-committed-event)
   ::new-commit)
 
 (defn broadcast-error!
   [broadcaster {:keys [ledger-id] :as error-event}]
-  (-broadcast broadcaster ledger-id error-event)
+  (-broadcast-error broadcaster ledger-id error-event)
   ::error)

--- a/src/fluree/server/broadcast/subscriptions.clj
+++ b/src/fluree/server/broadcast/subscriptions.clj
@@ -99,10 +99,13 @@
 
 (defrecord Subscriptions [state]
   Broadcaster
-  (-broadcast [_ ledger-id event]
+  (-broadcast-commit [_ ledger-id event]
     (let [action  (events/event-type event)
           message (select-keys event [:tx-id :commit :t])]
       (send-message-to-all state action ledger-id message)))
+  (-broadcast-error [_ ledger-id error-event]
+    ;; no-op as subscribers are only concerned with successful transactions
+    (log/debug "Skipping error broadcast of event" error-event "for ledger" ledger-id))
 
   Closeable
   (close [_]

--- a/src/fluree/server/command.clj
+++ b/src/fluree/server/command.clj
@@ -1,0 +1,79 @@
+(ns fluree.server.command
+  (:require [clojure.string :as str]
+            [clojure.tools.cli :as cli]))
+
+(set! *warn-on-reflection* true)
+
+(defn strip-leading-colon
+  [s]
+  (if (str/starts-with? s ":")
+    (subs s 1)
+    s))
+
+(defn profile-string->keyword
+  [s]
+  (-> s str/trim strip-leading-colon keyword))
+
+(def cli-options
+  [["-p" "--profile PROFILE" "Run profile"
+    :default  :prod
+    :parse-fn profile-string->keyword]
+   ["-c" "--config FILE" "Load configuration at a file path"]
+   ["-s" "--string STRING" "Load stringified configuration"]
+   ["-r" "--resource NAME" "Load pre-defined configuration resource"]
+   ["-h" "--help" "Print this usage summary and exit"]])
+
+(defn single-configuration?
+  [{:keys [config string resource]}]
+  (->> [config string resource] (remove nil?) count (>= 1)))
+
+(def multiple-configuration-error
+  (str "Only a single configuration option from"
+       "-c/--config, -s/--string, and -r/--resource"
+       "is allowed."))
+
+(defn validate-opts
+  [{:keys [options] :as parsed-opts}]
+  (if (single-configuration? options)
+    parsed-opts
+    (update parsed-opts :errors conj multiple-configuration-error)))
+
+(defn usage
+  [summary]
+  (str/join \newline ["Fluree Ledger Server"
+                      ""
+                      "Options:"
+                      summary]))
+
+(defn error-message
+  [errors]
+  (str/join \newline errors))
+
+(defn exit
+  [status message]
+  (println message)
+  (System/exit status))
+
+(defn parse
+  [args]
+  (-> args
+      (cli/parse-opts cli-options)
+      validate-opts))
+
+(defn verify
+  [{:keys [errors] :as cli}]
+  (if (seq errors)
+    (let [msg (error-message errors)]
+      (exit 1 msg))
+    cli))
+
+(defn describe
+  [{:keys [options summary] :as cli}]
+  (if (:help options)
+    (let [msg (usage summary)]
+      (exit 0 msg))
+    cli))
+
+(defn formulate
+  [args]
+  (-> args parse verify describe))

--- a/src/fluree/server/config.clj
+++ b/src/fluree/server/config.clj
@@ -67,11 +67,21 @@
 
 (defn read-resource
   [resource-name]
-  (-> resource-name io/resource slurp))
+  (try
+    (-> resource-name io/resource slurp)
+    (catch IllegalArgumentException e
+      (throw (ex-info (str "Unable to load configuration resource " resource-name)
+                      {:status 400, :error :server/missing-config}
+                      e)))))
 
 (defn read-file
   [path]
-  (-> path io/file slurp))
+  (try
+    (-> path io/file slurp)
+    (catch IllegalArgumentException e
+      (throw (ex-info (str "Unable to load configuration file at path: " path)
+                      {:status 400, :error :server/missing-config}
+                      e)))))
 
 (defn parse
   [cfg]

--- a/src/fluree/server/config.clj
+++ b/src/fluree/server/config.clj
@@ -69,6 +69,10 @@
   [resource-name]
   (-> resource-name io/resource slurp))
 
+(defn read-file
+  [path]
+  (-> path io/file slurp))
+
 (defn parse
   [cfg]
   (-> cfg

--- a/src/fluree/server/config.clj
+++ b/src/fluree/server/config.clj
@@ -72,5 +72,5 @@
 (defn parse
   [cfg]
   (-> cfg
-      (conn-config/parse (map derive-server-node-id))
+      (conn-config/parse derive-server-node-id)
       (assoc :fluree.server/subscriptions {})))

--- a/src/fluree/server/consensus/events.clj
+++ b/src/fluree/server/consensus/events.clj
@@ -7,10 +7,7 @@
   (:type event))
 
 (defn create-ledger
-  "Upon receiving a request to create a new ledger, an event
-  message must be queued into the consensus state machine.
-
-  Format is [event-name event-body]"
+  "Create a new event message to create a new ledger"
   [ledger-id tx-id txn opts]
   {:type      :ledger-create
    :txn       txn
@@ -21,10 +18,7 @@
    :instant   (System/currentTimeMillis)})
 
 (defn commit-transaction
-  "Upon receiving a request to create a new ledger, an event
-  message must be queued into the consensus state machine.
-
-  Format is [event-name event-body]"
+  "Create a new event message to commit a new transaction"
   [ledger-id tx-id txn opts]
   {:type      :tx-queue
    :txn       txn
@@ -37,32 +31,36 @@
 (defn transaction-committed
   "Post-transaction, the message we will broadcast out and/or deliver
   to a client awaiting a response."
-  ([{:keys [ledger-id tx-id] :as _event-params}
-    {:keys [db address] :as _commit-result}]
+  ([ledger-id tx-id {:keys [db address] :as _commit-result}]
    {:type      :transaction-committed
     :ledger-id ledger-id
     :t         (:t db)
     :tx-id     tx-id
     :commit    address})
-  ([processing-server event-params commit-result]
-   (-> (transaction-committed event-params commit-result)
+  ([processing-server ledger-id tx-id commit-result]
+   (-> (transaction-committed ledger-id tx-id commit-result)
        (assoc :server processing-server))))
 
 (defn ledger-created
-  ([event-params commit-result]
-   (-> event-params
-       (transaction-committed commit-result)
+  ([ledger-id tx-id commit-result]
+   (-> (transaction-committed ledger-id tx-id commit-result)
        (assoc :type :ledger-created)))
-  ([processing-server event-params commit-result]
-   (-> (ledger-created event-params commit-result)
+  ([processing-server ledger-id tx-id commit-result]
+   (-> (ledger-created ledger-id tx-id commit-result)
        (assoc :server processing-server))))
 
 (defn error
-  ([params exception]
-   (-> params
-       (select-keys [:ledger-id :tx-id])
-       (assoc :error-message (ex-message exception)
-              :error-data    (ex-data exception))))
-  ([processing-server params exception]
-   (-> (error params exception)
+  ([ledger-id tx-id exception]
+   (-> {:type          :error
+        :ledger-id     ledger-id
+        :tx-id         tx-id
+        :error         exception
+        :error-message (ex-message exception)
+        :error-data    (ex-data exception)}))
+  ([processing-server ledger-id tx-id exception]
+   (-> (error ledger-id tx-id exception)
        (assoc :server processing-server))))
+
+(defn error?
+  [evt]
+  (-> evt :type (= :error)))

--- a/src/fluree/server/consensus/events.clj
+++ b/src/fluree/server/consensus/events.clj
@@ -6,6 +6,10 @@
   [event]
   (:type event))
 
+(defn type?
+  [evt type]
+  (-> evt event-type (= type)))
+
 (defn create-ledger
   "Create a new event message to create a new ledger"
   [ledger-id tx-id txn opts]
@@ -41,6 +45,10 @@
    (-> (transaction-committed ledger-id tx-id commit-result)
        (assoc :server processing-server))))
 
+(defn transaction-committed?
+  [evt]
+  (type? evt :transaction-committed))
+
 (defn ledger-created
   ([ledger-id tx-id commit-result]
    (-> (transaction-committed ledger-id tx-id commit-result)
@@ -48,6 +56,10 @@
   ([processing-server ledger-id tx-id commit-result]
    (-> (ledger-created ledger-id tx-id commit-result)
        (assoc :server processing-server))))
+
+(defn ledger-created?
+  [evt]
+  (type? evt :ledger-created))
 
 (defn error
   ([ledger-id tx-id exception]
@@ -63,4 +75,4 @@
 
 (defn error?
   [evt]
-  (-> evt :type (= :error)))
+  (type? evt :error))

--- a/src/fluree/server/consensus/raft/handler.clj
+++ b/src/fluree/server/consensus/raft/handler.clj
@@ -27,14 +27,14 @@
                                          :instant   pos-int?}
                             :auth       {} ;; specific authorization logic to determine if action is allowed.
                             :handler    ledger-created/handler
-                            :processor  ledger-created/broadcast!}
+                            :processor  ledger-created/deliver!}
    :tx-queue               {:summary   "Queues a new transaction for a given ledger. If the transactor, processes transaction"
                             :produces-events [:new-commit :tx-exception]
                             :handler   tx-queue/handler
                             :processor tx-queue/processor}
    :new-commit             {:summary   "A transaction has been processed into a new commit. Broadcast to connected clients."
                             :handler   new-commit/handler
-                            :processor new-commit/broadcast!}
+                            :processor new-commit/deliver!}
    :tx-exception           {:summary "Any transaction that has an exception which is not recorded in a new commit.  Broadcast to connected clients."
                             :handler tx-exception/handler}
    :new-index-file         {:summary   "A new (pending) index file is created for an ongoing indexing process"

--- a/src/fluree/server/consensus/raft/handlers/create_ledger.clj
+++ b/src/fluree/server/consensus/raft/handlers/create_ledger.clj
@@ -56,10 +56,9 @@
   "Pushes create-ledger request in consensus only if leader.
 
   Returns promise that will have the eventual response once committed."
-  [{:keys [consensus/raft-state] :as config} params commit-result]
-  (let [created-body (events/transaction-committed ; same as new-commit message
-                      (participant/this-server raft-state)
-                      params commit-result)]
+  [{:keys [consensus/raft-state] :as config} {:keys [ledger-id tx-id] :as _params} commit-result]
+  (let [created-body (events/ledger-created (participant/this-server raft-state)
+                                            ledger-id tx-id commit-result)]
 
     ;; returns promise
     (participant/leader-new-command! config :ledger-created created-body)))

--- a/src/fluree/server/consensus/raft/handlers/ledger_created.clj
+++ b/src/fluree/server/consensus/raft/handlers/ledger_created.clj
@@ -82,7 +82,7 @@
 
         e*))))
 
-(defn broadcast!
+(defn deliver!
   "Responsible for producing the event broadcast to connected peers."
   [{:keys [fluree/watcher] :as _config} handler-result]
   (let [new-ledger-event (events/ledger-created {} handler-result)]

--- a/src/fluree/server/consensus/raft/handlers/ledger_created.clj
+++ b/src/fluree/server/consensus/raft/handlers/ledger_created.clj
@@ -3,8 +3,9 @@
             [clojure.java.io :as io]
             [fluree.db.util.filesystem :as fs]
             [fluree.db.util.log :as log]
-            [fluree.server.broadcast :as broadcast]
-            [fluree.server.consensus.raft.handlers.new-commit :as new-commit])
+            [fluree.server.consensus.raft.handlers.new-commit :as new-commit]
+            [fluree.server.consensus.events :as events]
+            [fluree.server.watcher :as watcher])
   (:import (java.io File)))
 
 (set! *warn-on-reflection* true)
@@ -83,5 +84,6 @@
 
 (defn broadcast!
   "Responsible for producing the event broadcast to connected peers."
-  [{:keys [fluree/watcher fluree/subscriptions] :as _config} handler-result]
-  (broadcast/broadcast-new-ledger! subscriptions watcher {} handler-result))
+  [{:keys [fluree/watcher] :as _config} handler-result]
+  (let [new-ledger-event (events/ledger-created {} handler-result)]
+    (watcher/deliver-commit watcher new-ledger-event)))

--- a/src/fluree/server/consensus/raft/handlers/ledger_created.clj
+++ b/src/fluree/server/consensus/raft/handlers/ledger_created.clj
@@ -3,8 +3,8 @@
             [clojure.java.io :as io]
             [fluree.db.util.filesystem :as fs]
             [fluree.db.util.log :as log]
-            [fluree.server.consensus.raft.handlers.new-commit :as new-commit]
             [fluree.server.consensus.events :as events]
+            [fluree.server.consensus.raft.handlers.new-commit :as new-commit]
             [fluree.server.watcher :as watcher])
   (:import (java.io File)))
 

--- a/src/fluree/server/consensus/raft/handlers/ledger_created.clj
+++ b/src/fluree/server/consensus/raft/handlers/ledger_created.clj
@@ -85,5 +85,5 @@
 (defn deliver!
   "Responsible for producing the event broadcast to connected peers."
   [{:keys [fluree/watcher] :as _config} handler-result]
-  (let [new-ledger-event (events/ledger-created {} handler-result)]
-    (watcher/deliver-commit watcher new-ledger-event)))
+  (let [new-ledger-event (events/ledger-created nil nil handler-result)]
+    (watcher/deliver-commit watcher nil nil new-ledger-event)))

--- a/src/fluree/server/consensus/raft/handlers/new_commit.clj
+++ b/src/fluree/server/consensus/raft/handlers/new_commit.clj
@@ -98,7 +98,7 @@
                   :error  :db/unexpected-error}
                  e)))))
 
-(defn broadcast!
+(defn deliver!
   "Responsible for producing the event broadcast to connected peers."
   [{:keys [fluree/watcher] :as _config} commit-result]
   (let [new-commit-event (events/transaction-committed {} commit-result)]

--- a/src/fluree/server/consensus/raft/handlers/new_commit.clj
+++ b/src/fluree/server/consensus/raft/handlers/new_commit.clj
@@ -101,5 +101,5 @@
 (defn deliver!
   "Responsible for producing the event broadcast to connected peers."
   [{:keys [fluree/watcher] :as _config} commit-result]
-  (let [new-commit-event (events/transaction-committed {} commit-result)]
+  (let [new-commit-event (events/transaction-committed nil nil commit-result)]
     (watcher/deliver-commit watcher new-commit-event)))

--- a/src/fluree/server/consensus/raft/handlers/new_commit.clj
+++ b/src/fluree/server/consensus/raft/handlers/new_commit.clj
@@ -8,7 +8,8 @@
             [fluree.db.util.filesystem :as fs]
             [fluree.db.util.json :as json]
             [fluree.db.util.log :as log]
-            [fluree.server.broadcast :as broadcast]))
+            [fluree.server.consensus.events :as events]
+            [fluree.server.watcher :as watcher]))
 
 (set! *warn-on-reflection* true)
 
@@ -99,5 +100,6 @@
 
 (defn broadcast!
   "Responsible for producing the event broadcast to connected peers."
-  [{:keys [fluree/watcher fluree/subscriptions] :as _config} commit-result]
-  (broadcast/broadcast-new-commit! subscriptions watcher {} commit-result))
+  [{:keys [fluree/watcher] :as _config} commit-result]
+  (let [new-commit-event (events/transaction-committed {} commit-result)]
+    (watcher/deliver-commit watcher new-commit-event)))

--- a/src/fluree/server/consensus/raft/handlers/new_commit.clj
+++ b/src/fluree/server/consensus/raft/handlers/new_commit.clj
@@ -102,4 +102,4 @@
   "Responsible for producing the event broadcast to connected peers."
   [{:keys [fluree/watcher] :as _config} commit-result]
   (let [new-commit-event (events/transaction-committed nil nil commit-result)]
-    (watcher/deliver-commit watcher new-commit-event)))
+    (watcher/deliver-commit watcher nil nil new-commit-event)))

--- a/src/fluree/server/consensus/raft/handlers/tx_exception.clj
+++ b/src/fluree/server/consensus/raft/handlers/tx_exception.clj
@@ -26,7 +26,7 @@
                   :error  :db/unexpected-error}
                  e)))))
 
-(defn broadcast!
+(defn deliver!
   [{:keys [fluree/watcher] :as _config} exception]
   (watcher/deliver-error watcher nil exception))
 
@@ -38,7 +38,7 @@
 
     (->> exception-meta
          (update-ledger-state config)
-         (broadcast! config))
+         (deliver! config))
 
     (catch Exception e
       (log/warn (str "Error recording transaction exception: " (ex-message e)))

--- a/src/fluree/server/consensus/raft/handlers/tx_exception.clj
+++ b/src/fluree/server/consensus/raft/handlers/tx_exception.clj
@@ -1,6 +1,6 @@
 (ns fluree.server.consensus.raft.handlers.tx-exception
   (:require [fluree.db.util.log :as log]
-            [fluree.server.broadcast :as broadcast]))
+            [fluree.server.watcher :as watcher]))
 
 (defn update-ledger-state
   "Updates the latest commit in the ledger, and removes the processed transaction in the queue"
@@ -27,8 +27,8 @@
                  e)))))
 
 (defn broadcast!
-  [{:keys [fluree/subscriptions fluree/watcher] :as _config} exception]
-  (broadcast/broadcast-error! subscriptions watcher {} exception))
+  [{:keys [fluree/watcher] :as _config} exception]
+  (watcher/deliver-error watcher nil exception))
 
 (defn handler
   "Handles transaction exceptions and broadcasts them to network."

--- a/src/fluree/server/consensus/raft/handlers/tx_exception.clj
+++ b/src/fluree/server/consensus/raft/handlers/tx_exception.clj
@@ -28,7 +28,7 @@
 
 (defn deliver!
   [{:keys [fluree/watcher] :as _config} exception]
-  (watcher/deliver-error watcher nil exception))
+  (watcher/deliver-error watcher nil nil exception))
 
 (defn handler
   "Handles transaction exceptions and broadcasts them to network."

--- a/src/fluree/server/consensus/raft/producers/new_commit.clj
+++ b/src/fluree/server/consensus/raft/producers/new_commit.clj
@@ -10,10 +10,9 @@
   This is called with new commits immediately after processing a transaction.
 
   Returns promise that will have the eventual response once committed."
-  [{:keys [consensus/raft-state] :as config} params commit-result]
-  (let [created-body (events/transaction-committed
-                      (participant/this-server raft-state)
-                      params commit-result)]
+  [{:keys [consensus/raft-state] :as config} {:keys [ledger-id tx-id] :as _params} commit-result]
+  (let [created-body (events/transaction-committed (participant/this-server raft-state)
+                                                   ledger-id tx-id commit-result)]
 
     ;; returns promise
     (participant/leader-new-command! config :new-commit created-body)))

--- a/src/fluree/server/consensus/raft/producers/tx_exception.clj
+++ b/src/fluree/server/consensus/raft/producers/tx_exception.clj
@@ -3,8 +3,8 @@
             [fluree.server.consensus.raft.participant :as participant]))
 
 (defn consensus-push-tx-exception
-  [{:keys [consensus/raft-state] :as config} params tx-exception]
+  [{:keys [consensus/raft-state] :as config} {:keys [ledger-id tx-id]} tx-exception]
   (let [server    (participant/this-server raft-state)
-        error-msg (events/error server params tx-exception)]
+        error-msg (events/error server ledger-id tx-id tx-exception)]
     ;; returns promise
     (participant/leader-new-command! config :tx-exception error-msg)))

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -119,7 +119,7 @@
   (ex-info "Too many pending transactions. Please try again later."
            {:status 503, :error :db/pending-transaction-limit}))
 
-(defrecord BufferedTransactor [tx-queue]
+(defrecord BufferedTransactor [watcher tx-queue]
   consensus/Transactor
   (-queue-new-ledger [_ new-ledger-event]
     (let [out-ch (async/chan)]
@@ -136,9 +136,9 @@
 (defn start-buffered
   [conn watcher max-pending-txns]
   (let [tx-queue (new-transaction-queue conn watcher max-pending-txns)]
-    (->BufferedTransactor tx-queue)))
+    (->BufferedTransactor watcher tx-queue)))
 
-(defrecord SynchronizedTransactor [tx-queue]
+(defrecord SynchronizedTransactor [watcher tx-queue]
   consensus/Transactor
   (-queue-new-ledger [_ new-ledger-event]
     (let [out-ch (async/chan)]
@@ -153,7 +153,7 @@
 (defn start-synchronized
   [conn watcher]
   (let [tx-queue (new-transaction-queue conn watcher)]
-    (->SynchronizedTransactor tx-queue)))
+    (->SynchronizedTransactor watcher tx-queue)))
 
 (defn start
   ([conn watcher]

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -172,14 +172,14 @@
    :handler    #'ledger/history})
 
 (defn wrap-assoc-system
-  [conn consensus watcher subscriptions broadcast handler]
+  [conn consensus watcher subscriptions broadcaster handler]
   (fn [req]
     (-> req
         (assoc :fluree/conn conn
                :fluree/consensus consensus
                :fluree/watcher watcher
                :fluree/subscriptions subscriptions
-               :fluree/broadcaster broadcast)
+               :fluree/broadcaster broadcaster)
         handler)))
 
 (defn wrap-cors
@@ -331,7 +331,8 @@
          resp)))))
 
 (defn compose-app-middleware
-  [{:keys [connection consensus watcher subscriptions broadcast root-identities closed-mode]
+  [{:keys [connection consensus watcher subscriptions broadcaster
+           root-identities closed-mode]
     :as _config}]
   (let [exception-middleware (exception/create-exception-middleware
                               (merge
@@ -349,7 +350,7 @@
     (sort-middleware-by-weight [[1 exception-middleware]
                                 [10 wrap-cors]
                                 [10 (partial wrap-assoc-system connection consensus
-                                             watcher subscriptions broadcast)]
+                                             watcher subscriptions broadcaster)]
                                 [50 unwrap-credential]
                                 [100 wrap-set-fuel-header]
                                 [200 coercion/coerce-exceptions-middleware]

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -424,18 +424,22 @@
                          500 {:body ErrorResponse}}
             :handler    #'srv-tx/callback}}]])
 
-(def default-fluree-routes
-  #{fluree-create-routes
-    fluree-transact-routes
-    fluree-query-routes
-    fluree-history-routes
-    fluree-remote-routes
-    fluree-subscription-routes
-    fluree-callback-routes})
+(def default-fluree-route-map
+  {:create       fluree-create-routes
+   :transact     fluree-transact-routes
+   :query        fluree-query-routes
+   :history      fluree-history-routes
+   :remote       fluree-remote-routes
+   :subscription fluree-subscription-routes})
 
 (defn combine-fluree-routes
-  [fluree-route-list]
-  (into ["/fluree"] fluree-route-list))
+  [fluree-route-map]
+  (->> fluree-route-map
+       vals
+       (into ["/fluree"])))
+
+(def default-fluree-routes
+  (combine-fluree-routes default-fluree-route-map))
 
 (def fallback-handler
   (let [swagger-ui-handler (swagger-ui/create-swagger-ui-handler
@@ -473,9 +477,8 @@
    (app config []))
   ([config custom-routes]
    (app config custom-routes default-fluree-routes))
-  ([config custom-routes fluree-route-list]
+  ([config custom-routes fluree-routes]
    (let [app-middleware (compose-app-middleware config)
-         fluree-routes  (combine-fluree-routes fluree-route-list)
          app-routes     (cond-> ["" {:middleware app-middleware} fluree-routes]
                           (seq custom-routes) (conj custom-routes))
          router         (app-router app-routes)]

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -75,13 +75,6 @@
               [:tx-id DID]
               [:commit  LedgerAddress]]]))
 
-(def TransactCallbackRequestBody
-  (m/schema [:map-of :any :any]))
-
-(def TransactCallbackResponseBody
-  (m/schema [:and
-             [:map-of :keyword :any]]))
-
 (def FqlQuery (m/schema (-> (fql/query-schema [])
                             ;; hack to make query schema open instead of closed
                             ;; TODO: remove once db is updated to open
@@ -413,16 +406,6 @@
    {:get {:summary    "Subscribe to ledger updates"
           :parameters {:body SubscriptionRequestBody}
           :handler    #'subscription/default}}])
-
-(def fluree-callback-routes
-  ["/callback"
-   ["/transaction"
-    {:post {:summary    "Report progress of delegated transaction processing"
-            :parameters {:body TransactCallbackRequestBody}
-            :responses  {200 {:body TransactCallbackResponseBody}
-                         400 {:body ErrorResponse}
-                         500 {:body ErrorResponse}}
-            :handler    #'srv-tx/callback}}]])
 
 (def default-fluree-route-map
   {:create       fluree-create-routes

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -172,13 +172,14 @@
    :handler    #'ledger/history})
 
 (defn wrap-assoc-system
-  [conn consensus watcher subscriptions handler]
+  [conn consensus watcher subscriptions broadcast handler]
   (fn [req]
     (-> req
         (assoc :fluree/conn conn
                :fluree/consensus consensus
                :fluree/watcher watcher
-               :fluree/subscriptions subscriptions)
+               :fluree/subscriptions subscriptions
+               :fluree/broadcaster broadcast)
         handler)))
 
 (defn wrap-cors
@@ -330,7 +331,7 @@
          resp)))))
 
 (defn compose-app-middleware
-  [{:keys [connection consensus watcher subscriptions root-identities closed-mode]
+  [{:keys [connection consensus watcher subscriptions broadcast root-identities closed-mode]
     :as _config}]
   (let [exception-middleware (exception/create-exception-middleware
                               (merge
@@ -348,7 +349,7 @@
     (sort-middleware-by-weight [[1 exception-middleware]
                                 [10 wrap-cors]
                                 [10 (partial wrap-assoc-system connection consensus
-                                             watcher subscriptions)]
+                                             watcher subscriptions broadcast)]
                                 [50 unwrap-credential]
                                 [100 wrap-set-fuel-header]
                                 [200 coercion/coerce-exceptions-middleware]

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -470,10 +470,13 @@
 
 (defn app
   ([config]
-   (app config default-fluree-routes))
-  ([config fluree-route-list]
+   (app config []))
+  ([config custom-routes]
+   (app config custom-routes default-fluree-routes))
+  ([config custom-routes fluree-route-list]
    (let [app-middleware (compose-app-middleware config)
          fluree-routes  (combine-fluree-routes fluree-route-list)
-         app-routes     ["" {:middleware app-middleware} fluree-routes]
+         app-routes     (cond-> ["" {:middleware app-middleware} fluree-routes]
+                          (seq custom-routes) (conj custom-routes))
          router         (app-router app-routes)]
      (ring/ring-handler router fallback-handler))))

--- a/src/fluree/server/handlers/create.clj
+++ b/src/fluree/server/handlers/create.clj
@@ -1,6 +1,5 @@
 (ns fluree.server.handlers.create
   (:require
-   [clojure.core.async :as async :refer [go <!]]
    [fluree.db.api :as fluree]
    [fluree.db.constants :as const]
    [fluree.db.util.context :as ctx-util]

--- a/src/fluree/server/handlers/create.clj
+++ b/src/fluree/server/handlers/create.clj
@@ -8,7 +8,7 @@
    [fluree.db.util.log :as log]
    [fluree.json-ld.processor.api :as jld-processor]
    [fluree.server.consensus :as consensus]
-   [fluree.server.consensus.watcher :as watcher]
+   [fluree.server.watcher :as watcher]
    [fluree.server.handlers.shared :refer [deref! defhandler]]
    [fluree.server.handlers.transact :refer [derive-tx-id]]))
 

--- a/src/fluree/server/handlers/create.clj
+++ b/src/fluree/server/handlers/create.clj
@@ -7,10 +7,10 @@
    [fluree.db.util.log :as log]
    [fluree.json-ld.processor.api :as jld-processor]
    [fluree.server.consensus :as consensus]
-   [fluree.server.watcher :as watcher]
    [fluree.server.handlers.shared :refer [deref! defhandler]]
    [fluree.server.handlers.transact :refer [derive-tx-id monitor-consensus-persistence
-                                            monitor-commit]]))
+                                            monitor-commit]]
+   [fluree.server.watcher :as watcher]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -95,16 +95,3 @@
             resp-p (transact! consensus watcher expanded-txn opts)]
         {:status 200, :body (deref! resp-p)})
       (throw-ledger-doesnt-exist ledger-id))))
-
-(defhandler callback
-  [{:fluree/keys   [watcher]
-    {:keys [body]} :parameters}]
-  (let [{:keys [tx-id status]} body]
-    (if (= status "ok")
-      (let [event (dissoc body :status)]
-        (watcher/deliver-commit watcher tx-id event))
-      (let [{:keys [error-msg error-data]}
-            body
-            ex (ex-info error-msg error-data)]
-        (watcher/deliver-error watcher tx-id ex)))
-    {:status 200, :body {:status "ok"}}))

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -9,7 +9,7 @@
             [fluree.json-ld :as json-ld]
             [fluree.json-ld.processor.api :as jld-processor]
             [fluree.server.consensus :as consensus]
-            [fluree.server.consensus.watcher :as watcher]
+            [fluree.server.watcher :as watcher]
             [fluree.server.handlers.shared :refer [defhandler deref!]]))
 
 (set! *warn-on-reflection* true)

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -1,5 +1,5 @@
 (ns fluree.server.handlers.transact
-  (:require [clojure.core.async :as async]
+  (:require [clojure.core.async :as async :refer [<! go]]
             [fluree.crypto :as crypto]
             [fluree.db.api :as fluree]
             [fluree.db.constants :as const]
@@ -8,7 +8,9 @@
             [fluree.db.util.log :as log]
             [fluree.json-ld :as json-ld]
             [fluree.json-ld.processor.api :as jld-processor]
+            [fluree.server.broadcast :as broadcast]
             [fluree.server.consensus :as consensus]
+            [fluree.server.consensus.events :as events]
             [fluree.server.watcher :as watcher]
             [fluree.server.handlers.shared :refer [defhandler deref!]]))
 
@@ -21,57 +23,79 @@
     (-> (json-ld/normalize-data raw-txn)
         (crypto/sha2-256 :hex :string))))
 
+(defn monitor-consensus-persistence
+  [watcher ledger tx-id persist-resp-ch]
+  (go
+    (let [persist-resp (<! persist-resp-ch)]
+      ;; check for exception trying to put txn in consensus, if so we must deliver the
+      ;; watch here, but if successful the consensus process will deliver the watch downstream
+      (when (util/exception? persist-resp)
+        (watcher/deliver-error watcher ledger tx-id persist-resp)))))
+
 (defn queue-consensus
+  "Register a new commit with consensus"
   [consensus watcher ledger tx-id expanded-txn opts]
   (let [;; initial response is not completion, but acknowledgement of persistence
         persist-resp-ch (consensus/queue-new-transaction consensus ledger tx-id
                                                          expanded-txn opts)]
-    (async/go
-      (let [persist-resp (async/<! persist-resp-ch)]
-        ;; check for exception trying to put txn in consensus, if so we must deliver the
-        ;; watch here, but if successful the consensus process will deliver the watch downstream
-        (when (util/exception? persist-resp)
-          (watcher/deliver-error watcher tx-id persist-resp))))))
+    (monitor-consensus-persistence watcher ledger tx-id persist-resp-ch)))
+
+(defn monitor-commit
+  "Wait for final commit result from consensus on `result-ch`, broadcast to any
+  subscribers and deliver response to promise `out-p`"
+  [out-p ledger-id tx-id broadcaster result-ch]
+  (go
+    (let [result (async/<! result-ch)]
+      (log/debug "HTTP API transaction final response: " result)
+      (cond
+        (= :timeout result)
+        (let [ex          (ex-info (str "Timeout waiting for transaction to complete for: "
+                                        ledger-id " with tx-id: " tx-id)
+                                   {:status 408, :error :db/response-timeout})
+              error-event (events/error ledger-id tx-id ex)]
+          (broadcast/broadcast-error! broadcaster error-event)
+          (deliver out-p ex))
+
+        (nil? result)
+        (let [ex          (ex-info (str "Missing transaction result for ledger: "
+                                        ledger-id " with tx-id: " tx-id
+                                        ". Transaction may have processed, check ledger"
+                                        " for confirmation.")
+                                   {:status 500, :error :db/response-missing})
+              error-event (events/error ledger-id tx-id ex)]
+          (broadcast/broadcast-error! broadcaster error-event)
+          (deliver out-p ex))
+
+        (util/exception? result)
+        (let [error-event (events/error ledger-id tx-id result)]
+          (broadcast/broadcast-error! broadcaster error-event)
+          (deliver out-p result))
+
+        (events/error? result)
+        (let [ex (:error result)]
+          (broadcast/broadcast-error! broadcaster result)
+          (deliver out-p ex))
+
+        :else
+        (let [{:keys [ledger-id commit t tx-id]} result]
+          (log/info "Transaction completed for:" ledger-id "tx-id:" tx-id
+                    "commit head:" commit)
+          (case (events/event-type result)
+            :transaction-committed (broadcast/broadcast-new-commit! broadcaster result)
+            :ledger-created        (broadcast/broadcast-new-ledger! broadcaster result))
+          (deliver out-p {:ledger ledger-id
+                          :commit commit
+                          :t      t
+                          :tx-id  tx-id}))))))
 
 (defn transact!
-  [consensus watcher expanded-txn opts]
+  [consensus watcher broadcaster expanded-txn opts]
   (let [p         (promise)
         ledger-id (get-first-value expanded-txn const/iri-ledger)
         tx-id     (derive-tx-id (:raw-txn opts))
         result-ch (watcher/create-watch watcher tx-id)]
-
-    ;; register transaction into consensus
     (queue-consensus consensus watcher ledger-id tx-id expanded-txn opts)
-
-    ;; wait for final response from consensus and deliver to promise
-    (async/go
-      (let [result (async/<! result-ch)]
-        (log/debug "HTTP API transaction final response: " result)
-        (cond
-          (= :timeout result)
-          (deliver p (ex-info
-                      (str "Timeout waiting for transaction to complete for: "
-                           ledger-id " with tx-id: " tx-id)
-                      {:status 408 :error :db/response-timeout}))
-
-          (nil? result)
-          (deliver p (ex-info
-                      (str "Unexpected close waiting for ledger transaction to complete for: "
-                           ledger-id " with tx-id: " tx-id
-                           ". Transaction may have processed, check ledger for confirmation.")
-                      {:status 500 :error :db/response-closed}))
-
-          (util/exception? result)
-          (deliver p result)
-
-          :else
-          (let [{:keys [ledger-id commit t tx-id]} result]
-            (log/info "Transaction completed for:" ledger-id "tx-id:" tx-id
-                      "commit head:" commit)
-            (deliver p {:ledger ledger-id
-                        :commit commit
-                        :t      t
-                        :tx-id  tx-id})))))
+    (monitor-commit p ledger-id tx-id broadcaster result-ch)
     p))
 
 (defn throw-ledger-doesnt-exist
@@ -82,7 +106,7 @@
                                 :body   {:error err-message}}}))))
 
 (defhandler default
-  [{:keys [fluree/conn fluree/consensus fluree/watcher credential/did raw-txn]
+  [{:keys [fluree/conn fluree/consensus fluree/watcher fluree/broadcaster credential/did raw-txn]
     {:keys [body]} :parameters}]
   (let [txn-context    (ctx-util/txn-context body)
         [expanded-txn] (-> (ctx-util/use-fluree-context body)
@@ -92,6 +116,6 @@
     (if (deref! (fluree/exists? conn ledger-id))
       (let [opts   (cond-> {:context txn-context :raw-txn raw-txn}
                      did (assoc :did did))
-            resp-p (transact! consensus watcher expanded-txn opts)]
+            resp-p (transact! consensus watcher broadcaster expanded-txn opts)]
         {:status 200, :body (deref! resp-p)})
       (throw-ledger-doesnt-exist ledger-id))))

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -80,9 +80,7 @@
         (let [{:keys [ledger-id commit t tx-id]} result]
           (log/info "Transaction completed for:" ledger-id "tx-id:" tx-id
                     "commit head:" commit)
-          (case (events/event-type result)
-            :transaction-committed (broadcast/broadcast-new-commit! broadcaster result)
-            :ledger-created        (broadcast/broadcast-new-ledger! broadcaster result))
+          (broadcast/broadcast-event! broadcaster result)
           (deliver out-p {:ledger ledger-id
                           :commit commit
                           :t      t

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -11,8 +11,8 @@
             [fluree.server.broadcast :as broadcast]
             [fluree.server.consensus :as consensus]
             [fluree.server.consensus.events :as events]
-            [fluree.server.watcher :as watcher]
-            [fluree.server.handlers.shared :refer [defhandler deref!]]))
+            [fluree.server.handlers.shared :refer [defhandler deref!]]
+            [fluree.server.watcher :as watcher]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/fluree/server/system.clj
+++ b/src/fluree/server/system.clj
@@ -1,69 +1,73 @@
 (ns fluree.server.system
-  (:require [fluree.db.connection.config :as conn-config]
+  (:require [fluree.db :as-alias db]
+            [fluree.db.connection.config :as conn-config]
             [fluree.db.connection.system :as conn-system]
             [fluree.db.connection.vocab :as conn-vocab]
             [fluree.db.util.core :as util :refer [get-first]]
+            [fluree.server :as-alias server]
             [fluree.server.broadcast.subscriptions :as subscriptions]
             [fluree.server.config :as config]
             [fluree.server.config.vocab :as server-vocab]
+            [fluree.server.consensus :as-alias consensus]
             [fluree.server.consensus.raft :as raft]
             [fluree.server.consensus.standalone :as standalone]
             [fluree.server.consensus.watcher :as watcher]
             [fluree.server.handler :as handler]
+            [fluree.server.http :as-alias http]
             [fluree.server.task.migrate-sid :as task.migrate-sid]
             [integrant.core :as ig]
             [ring.adapter.jetty9 :as jetty]))
 
 (set! *warn-on-reflection* true)
 
-(derive :fluree.server.consensus/raft :fluree.server/consensus)
-(derive :fluree.server.consensus/standalone :fluree.server/consensus)
-(derive :fluree.server/subscriptions :fluree.server/broadcast)
-(derive :fluree.server.http/jetty :fluree.server/http)
+(derive ::consensus/raft ::server/consensus)
+(derive ::consensus/standalone ::server/consensus)
+(derive ::server/subscriptions ::server/broadcast)
+(derive ::http/jetty ::server/http)
 
-(defmethod ig/expand-key :fluree.server/http
+(defmethod ig/expand-key ::server/http
   [k config]
   (let [max-txn-wait-ms (conn-config/get-first-integer config server-vocab/max-txn-wait-ms)
         closed-mode     (conn-config/get-first-boolean config server-vocab/closed-mode)
         root-identities (set (conn-config/get-strings config server-vocab/root-identities))
         config*         (-> config
-                            (assoc :handler (ig/ref :fluree.server.api/handler))
+                            (assoc :handler (ig/ref ::server/handler))
                             (dissoc server-vocab/max-txn-wait-ms server-vocab/closed-mode
                                     server-vocab/root-identities))]
-    {k                          config*
-     :fluree.server/watcher     {:max-txn-wait-ms max-txn-wait-ms}
-     :fluree.server.api/handler {:root-identities root-identities
-                                 :closed-mode     closed-mode
-                                 :connection      (ig/ref :fluree.db/connection)
-                                 :consensus       (ig/ref :fluree.server/consensus)
-                                 :watcher         (ig/ref :fluree.server/watcher)
-                                 :subscriptions   (ig/ref :fluree.server/subscriptions)}}))
+    {k                config*
+     ::server/watcher {:max-txn-wait-ms max-txn-wait-ms}
+     ::server/handler {:root-identities root-identities
+                       :closed-mode     closed-mode
+                       :connection      (ig/ref ::db/connection)
+                       :consensus       (ig/ref ::server/consensus)
+                       :watcher         (ig/ref ::server/watcher)
+                       :subscriptions   (ig/ref ::server/subscriptions)}}))
 
-(defmethod ig/expand-key :fluree.server.consensus/standalone
+(defmethod ig/expand-key ::consensus/standalone
   [k config]
   {k (assoc config
-            :broadcaster (ig/ref :fluree.server/broadcast)
-            :watcher (ig/ref :fluree.server/watcher))})
+            :broadcaster (ig/ref ::server/broadcast)
+            :watcher (ig/ref ::server/watcher))})
 
-(defmethod ig/init-key :fluree.server/subscriptions
+(defmethod ig/init-key ::server/subscriptions
   [_ _]
   (subscriptions/listen))
 
-(defmethod ig/halt-key! :fluree.server/subscriptions
+(defmethod ig/halt-key! ::server/subscriptions
   [_ subs]
   (subscriptions/close subs))
 
-(defmethod ig/init-key :fluree.server/watcher
+(defmethod ig/init-key ::server/watcher
   [_ {:keys [max-txn-wait-ms]}]
   (if max-txn-wait-ms
     (watcher/start max-txn-wait-ms)
     (watcher/start)))
 
-(defmethod ig/halt-key! :fluree.server/watcher
+(defmethod ig/halt-key! ::server/watcher
   [_ watcher]
   (watcher/stop watcher))
 
-(defmethod ig/init-key :fluree.server.consensus/raft
+(defmethod ig/init-key ::consensus/raft
   [_ config]
   (let [log-history      (conn-config/get-first-integer config server-vocab/log-history)
         entries-max      (conn-config/get-first-integer config server-vocab/entries-max)
@@ -80,37 +84,37 @@
                  :log-directory    log-directory
                  :ledger-directory ledger-directory})))
 
-(defmethod ig/halt-key! :fluree.server.consensus/raft
+(defmethod ig/halt-key! ::consensus/raft
   [_ {:keys [close] :as _raft-group}]
   (close))
 
-(defmethod ig/init-key :fluree.server.consensus/standalone
+(defmethod ig/init-key ::consensus/standalone
   [_ {:keys [broadcaster watcher] :as config}]
   (let [max-pending-txns (conn-config/get-first-integer config server-vocab/max-pending-txns)
         conn             (get-first config conn-vocab/connection)]
     (standalone/start conn broadcaster watcher max-pending-txns)))
 
-(defmethod ig/halt-key! :fluree.server.consensus/standalone
+(defmethod ig/halt-key! ::consensus/standalone
   [_ transactor]
   (standalone/stop transactor))
 
-(defmethod ig/init-key :fluree.server.api/handler
+(defmethod ig/init-key ::server/handler
   [_ config]
   (-> config
       (select-keys [:connection :consensus :watcher :subscriptions :root-identities
                     :closed-mode])
       handler/app))
 
-(defmethod ig/init-key :fluree.server.http/jetty
+(defmethod ig/init-key ::http/jetty
   [_ {:keys [handler] :as config}]
   (let [port (conn-config/get-first-integer config server-vocab/http-port)]
     (jetty/run-jetty handler {:port port, :join? false})))
 
-(defmethod ig/halt-key! :fluree.server.http/jetty
+(defmethod ig/halt-key! ::http/jetty
   [_ http-server]
   (jetty/stop-server http-server))
 
-(defmethod ig/init-key :fluree.server/sid-migration
+(defmethod ig/init-key ::server/sid-migration
   [_ {:keys [conn ledgers force]}]
   (task.migrate-sid/migrate conn ledgers force))
 

--- a/src/fluree/server/system.clj
+++ b/src/fluree/server/system.clj
@@ -125,7 +125,7 @@
   ([config]
    (start-config config nil))
   ([config _profile]
-   (-> config config/parse conn-system/parsed-initialize)))
+   (-> config config/parse conn-system/initialize)))
 
 (defn start-file
   ([path]

--- a/src/fluree/server/system.clj
+++ b/src/fluree/server/system.clj
@@ -11,10 +11,10 @@
             [fluree.server.consensus :as-alias consensus]
             [fluree.server.consensus.raft :as raft]
             [fluree.server.consensus.standalone :as standalone]
-            [fluree.server.watcher :as watcher]
             [fluree.server.handler :as handler]
             [fluree.server.http :as-alias http]
             [fluree.server.task.migrate-sid :as task.migrate-sid]
+            [fluree.server.watcher :as watcher]
             [integrant.core :as ig]
             [ring.adapter.jetty9 :as jetty]))
 

--- a/src/fluree/server/system.clj
+++ b/src/fluree/server/system.clj
@@ -41,7 +41,8 @@
                        :connection      (ig/ref ::db/connection)
                        :consensus       (ig/ref ::server/consensus)
                        :watcher         (ig/ref ::server/watcher)
-                       :subscriptions   (ig/ref ::server/subscriptions)}}))
+                       :subscriptions   (ig/ref ::server/subscriptions)
+                       :broadcaster     (ig/ref ::server/broadcast)}}))
 
 (defmethod ig/expand-key ::consensus/standalone
   [k config]
@@ -101,7 +102,7 @@
 (defmethod ig/init-key ::server/handler
   [_ config]
   (-> config
-      (select-keys [:connection :consensus :watcher :subscriptions :root-identities
+      (select-keys [:connection :consensus :watcher :subscriptions :broadcaster :root-identities
                     :closed-mode])
       handler/app))
 

--- a/src/fluree/server/system.clj
+++ b/src/fluree/server/system.clj
@@ -46,9 +46,7 @@
 
 (defmethod ig/expand-key ::consensus/standalone
   [k config]
-  {k (assoc config
-            :broadcaster (ig/ref ::server/broadcast)
-            :watcher (ig/ref ::server/watcher))})
+  {k (assoc config :watcher (ig/ref ::server/watcher))})
 
 (defmethod ig/init-key ::server/subscriptions
   [_ _]
@@ -90,10 +88,10 @@
   (close))
 
 (defmethod ig/init-key ::consensus/standalone
-  [_ {:keys [broadcaster watcher] :as config}]
+  [_ {:keys [watcher] :as config}]
   (let [max-pending-txns (conn-config/get-first-integer config server-vocab/max-pending-txns)
         conn             (get-first config conn-vocab/connection)]
-    (standalone/start conn broadcaster watcher max-pending-txns)))
+    (standalone/start conn watcher max-pending-txns)))
 
 (defmethod ig/halt-key! ::consensus/standalone
   [_ transactor]

--- a/src/fluree/server/system.clj
+++ b/src/fluree/server/system.clj
@@ -1,6 +1,5 @@
 (ns fluree.server.system
-  (:require [clojure.java.io :as io]
-            [fluree.db.connection.config :as conn-config]
+  (:require [fluree.db.connection.config :as conn-config]
             [fluree.db.connection.system :as conn-system]
             [fluree.db.connection.vocab :as conn-vocab]
             [fluree.db.util.core :as util :refer [get-first]]
@@ -132,8 +131,7 @@
    (start-file path :prod))
   ([path profile]
    (-> path
-       io/file
-       slurp
+       config/read-file
        (start-config profile))))
 
 (defn start-resource

--- a/src/fluree/server/system.clj
+++ b/src/fluree/server/system.clj
@@ -11,7 +11,7 @@
             [fluree.server.consensus :as-alias consensus]
             [fluree.server.consensus.raft :as raft]
             [fluree.server.consensus.standalone :as standalone]
-            [fluree.server.consensus.watcher :as watcher]
+            [fluree.server.watcher :as watcher]
             [fluree.server.handler :as handler]
             [fluree.server.http :as-alias http]
             [fluree.server.task.migrate-sid :as task.migrate-sid]

--- a/src/fluree/server/watcher.clj
+++ b/src/fluree/server/watcher.clj
@@ -1,4 +1,4 @@
-(ns fluree.server.consensus.watcher
+(ns fluree.server.watcher
   "System to manage and track pending requests through consensus in order to
   respond with the result. When mutation requests happen over http (e.g.
   creating a new ledger), we want to wait for the operation to complete through

--- a/src/fluree/server/watcher.clj
+++ b/src/fluree/server/watcher.clj
@@ -14,6 +14,7 @@
 
 (defprotocol Watcher
   (create-watch [w id])
+  (watching? [w id])
   (-deliver-event [w id event]))
 
 (defn new-watcher-atom
@@ -57,6 +58,8 @@
   Watcher
   (create-watch [_ id]
     (create-watch-state state max-txn-wait-ms id))
+  (watching? [_ id]
+    (contains? @state id))
   (-deliver-event [_ id event]
     ;; note: this can have a race condition, but given it is a promise chan, the
     ;; second put! will be ignored

--- a/src/fluree/server/watcher.clj
+++ b/src/fluree/server/watcher.clj
@@ -80,9 +80,8 @@
     (deliver-error-state state id error)))
 
 (defn deliver-commit
-  [w id event]
-  (let [{:keys [ledger-id t commit]} event]
-    (-deliver-commit w id ledger-id t commit)))
+  [w {:keys [ledger-id tx-id t commit] :as _event}]
+  (-deliver-commit w tx-id ledger-id t commit))
 
 (defn deliver-error
   [w id error]

--- a/src/fluree/server/watcher.clj
+++ b/src/fluree/server/watcher.clj
@@ -6,7 +6,7 @@
   operations get delivered via consensus, where they end up being picked up by a
   responsible server from a queue, processed, and then the results broadcast
   back out."
-  (:require [clojure.core.async :as async]
+  (:require [clojure.core.async :as async :refer [<! go]]
             [fluree.db.util.log :as log]
             [fluree.server.consensus.events :as events]))
 
@@ -33,8 +33,8 @@
   (let [promise-ch (async/promise-chan)]
     (swap! state assoc id promise-ch)
     (when max-txn-wait-ms
-      (async/go
-        (async/<! (async/timeout max-txn-wait-ms))
+      (go
+        (<! (async/timeout max-txn-wait-ms))
         ;; we close the promise chan when delivering, so put! will be false if
         ;; response already delivered
         (when (async/put! promise-ch :timeout)


### PR DESCRIPTION
This patch separates the transaction watching logic, which is mainly to allow processes local to the server instance to monitor a transaction, from the broadcasting logic, which allows connected systems to monitor the changes to a ledger. Separating those two abstractions allows them to be used and built upon more easily independently. 

This patch also provides a method to inject custom routes into the request handler at start time to allow for customizing the types of requests a server deployment can accept. 

Lastly, this patch refactors some of the command processing code for easier reuse. 