### PR TITLE
add support for application/sparql-update transaction requests

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "0ec05a8119de48a5055582d75c738df9f2902298"}
+                                :git/sha "ecc12f1ac354c9ce49dd81ddea270f95582362f0"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "e345dd96fa0b7641e7dd93a9333484a5b590ed8f"}
+                                :git/sha "0ec05a8119de48a5055582d75c738df9f2902298"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -65,7 +65,9 @@
              http/ws-upgrade-request?]))
 
 (def TransactRequestBody
-  (m/schema [:map-of :any :any]))
+  (m/schema [:orn
+             [:sparql :string]
+             [:fql [:map-of :any :any]]]))
 
 (def TransactResponseBody
   (m/schema [:and
@@ -288,6 +290,8 @@
           ;; Content-Type header takes precedence over other ways of specifying query format
           format        (cond (-> headers (get "content-type") (= "application/sparql-query"))
                               :sparql
+                              (-> headers (get "content-type") (= "application/sparql-update"))
+                              :sparql
 
                               (= format "sparql") :sparql
                               (= output "fql")    :fql
@@ -344,6 +348,16 @@
                     {::query  (String. (.readAllBytes ^InputStream data)
                                        ^String charset)
                      ::format :sparql})))]}))
+
+(def sparql-update-format
+  (mf/map->Format
+   {:name "application/sparql-update"
+    :decoder [(fn [_]
+                (reify
+                  mf/Decode
+                  (decode [_ data charset]
+                    (String. (.readAllBytes ^InputStream data)
+                             ^String charset))))]}))
 
 (def jwt-format
   "Turn a JWT from an InputStream into a string that will be found on :body-params in the
@@ -489,6 +503,7 @@
                     (-> muuntaja/default-options
                         (assoc-in [:formats "application/json"] json-format)
                         (assoc-in [:formats "application/sparql-query"] sparql-format)
+                        (assoc-in [:formats "application/sparql-update"] sparql-update-format)
                         (assoc-in [:formats "application/jwt"] jwt-format)))
         middleware [swagger/swagger-feature
                     muuntaja-mw/format-negotiate-middleware

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -105,7 +105,7 @@
 (defhandler default
   [{:keys [fluree/conn fluree/consensus fluree/watcher fluree/broadcaster credential/did fluree/opts raw-txn]
     {:keys [body]} :parameters}]
-  (let [txn            (if (= :sparql (:format opts))
+  (let [txn            (if (sparql/sparql-format? opts)
                          (sparql/->fql body)
                          body)
         txn-context    (ctx-util/txn-context txn)

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -3,6 +3,7 @@
             [fluree.crypto :as crypto]
             [fluree.db.api :as fluree]
             [fluree.db.api.transact :as transact-api]
+            [fluree.db.query.sparql :as sparql]
             [fluree.db.util.context :as ctx-util]
             [fluree.db.util.core :as util]
             [fluree.db.util.log :as log]
@@ -102,13 +103,16 @@
                                 :body   {:error err-message}}}))))
 
 (defhandler default
-  [{:keys [fluree/conn fluree/consensus fluree/watcher fluree/broadcaster credential/did raw-txn]
+  [{:keys [fluree/conn fluree/consensus fluree/watcher fluree/broadcaster credential/did fluree/opts raw-txn]
     {:keys [body]} :parameters}]
-  (let [txn-context    (ctx-util/txn-context body)
-        ledger-id      (transact-api/extract-ledger-id body)]
+  (let [txn            (if (= :sparql (:format opts))
+                         (sparql/->fql body)
+                         body)
+        txn-context    (ctx-util/txn-context txn)
+        ledger-id      (transact-api/extract-ledger-id txn)]
     (if (deref! (fluree/exists? conn ledger-id))
-      (let [opts   (cond-> {:context txn-context :raw-txn raw-txn}
-                     did (assoc :did did))
-            resp-p (transact! consensus watcher broadcaster ledger-id body opts)]
+      (let [opts (cond-> (merge opts {:context txn-context :raw-txn raw-txn :format :fql})
+                   did (assoc :did did))
+            resp-p (transact! consensus watcher broadcaster ledger-id txn opts)]
         {:status 200, :body (deref! resp-p)})
       (throw-ledger-doesnt-exist ledger-id))))

--- a/test/fluree/server/integration/test_system.clj
+++ b/test/fluree/server/integration/test_system.clj
@@ -21,6 +21,10 @@
   {"Content-Type" "application/sparql-query"
    "Accept"       "application/sparql-results+json"})
 
+(def sparql-update-headers
+  {"Content-Type" "application/sparql-update"
+   "Accept"       "application/json"})
+
 (def jwt-headers
   {"Content-Type" "application/jwt"
    "Accept"       "application/json"})


### PR DESCRIPTION
Implements the SPARQL Protocol [update operation](https://www.w3.org/TR/2013/REC-sparql11-protocol-20130321/#update-operation).

In lieu of pushing down sparql translation to the `db` api, this PR just translates the SPARQL update into fql at the first opportunity in order to minimize structural changes to transaction processing which depends on txn introspection.

Depends on https://github.com/fluree/db/pull/992

https://github.com/fluree/core/issues/175