### PR TITLE
Feature/consensus broadcast

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ clj-kondo-lint-ci:
 cljfmt-check: ## Check Clojure formatting with cljfmt
 	cljfmt check src test build.clj
 
+.PHONY: cljfmt-fix ## Fix Clojure formatting errors with cljfmt
+cljfmt-fix:
+	cljfmt fix src dev test build.clj
+
 .PHONY: clean
 clean: ## Remove build artifacts
 	rm -rf target

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "ecc12f1ac354c9ce49dd81ddea270f95582362f0"}
+                                :git/sha "c8d73d693af885e06d40f31e00b6de142f3e28a6"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 

--- a/dev/src/api_calls.clj
+++ b/dev/src/api_calls.clj
@@ -1,7 +1,6 @@
 (ns api-calls
   (:require [fluree.db.api :as fluree]))
 
-
 (comment
   (def conn @(fluree/connect {:method       :file,
                               :parallelism  2,
@@ -12,6 +11,4 @@
                                              :indexer {:reindex-min-bytes 9
                                                        :reindex-max-bytes 10000000}}}))
 
-  (def ledger @(fluree/load conn "my/test1"))
-
-  )
+  (def ledger @(fluree/load conn "my/test1")))

--- a/dev/src/http_calls.clj
+++ b/dev/src/http_calls.clj
@@ -4,58 +4,53 @@
             [fluree.server.consensus.network.multi-addr :refer [multi->map]]
             [user :as user]))
 
-
 (def ledger-name "my/test")
 
 (def server-1-address "http://localhost:58090/")
 (def server-2-address "http://localhost:58091/")
 (def server-3-address "http://localhost:58092/")
 
-
 (comment
 
- (-> (client/get (str server-1-address "swagger.json"))
-     :body
-     (json/parse false))
+  (-> (client/get (str server-1-address "swagger.json"))
+      :body
+      (json/parse false))
 
- (-> (client/post (str server-1-address "fluree/create")
-                  {:body               (json/stringify-UTF8
-                                        {
-                                         "@context" {"ex" "http://example.org/"}
-                                         "ledger"   ledger-name
-                                         "insert"   {"@id"     "ex:test1"
-                                                     "ex:name" "Brian"}})
+  (-> (client/post (str server-1-address "fluree/create")
+                   {:body               (json/stringify-UTF8
+                                         {"@context" {"ex" "http://example.org/"}
+                                          "ledger"   ledger-name
+                                          "insert"   {"@id"     "ex:test1"
+                                                      "ex:name" "Brian"}})
                    ;:headers {"X-Api-Version" "2"}
-                   :content-type       :json
-                   :socket-timeout     1000 ;; in milliseconds
-                   :connection-timeout 1000 ;; in milliseconds
-                   :accept             :json}))
+                    :content-type       :json
+                    :socket-timeout     1000 ;; in milliseconds
+                    :connection-timeout 1000 ;; in milliseconds
+                    :accept             :json}))
 
- (-> (client/post (str server-1-address "fluree/transact")
-                  {:body               (json/stringify-UTF8
-                                        {"@context" {"ex" "http://example.org/"}
-                                         "ledger"   ledger-name
-                                         "insert"   {"@id"     "ex:test2"
-                                                     "ex:name" "Brian2"}})
+  (-> (client/post (str server-1-address "fluree/transact")
+                   {:body               (json/stringify-UTF8
+                                         {"@context" {"ex" "http://example.org/"}
+                                          "ledger"   ledger-name
+                                          "insert"   {"@id"     "ex:test2"
+                                                      "ex:name" "Brian2"}})
                    ;:headers {"X-Api-Version" "2"}
-                   :content-type       :json
-                   :socket-timeout     1000 ;; in milliseconds
-                   :connection-timeout 1000 ;; in milliseconds
-                   :accept             :json}))
+                    :content-type       :json
+                    :socket-timeout     1000 ;; in milliseconds
+                    :connection-timeout 1000 ;; in milliseconds
+                    :accept             :json}))
 
- (-> (client/post (str server-1-address "fluree/query")
-                  {:body               (json/stringify-UTF8
-                                        {"@context" {"ex" "http://example.org/"}
-                                         "select"   {"?s" ["*"]}
-                                         "from"     ledger-name
-                                         "where"    {"@id"     "?s"
-                                                     "ex:name" nil}})
+  (-> (client/post (str server-1-address "fluree/query")
+                   {:body               (json/stringify-UTF8
+                                         {"@context" {"ex" "http://example.org/"}
+                                          "select"   {"?s" ["*"]}
+                                          "from"     ledger-name
+                                          "where"    {"@id"     "?s"
+                                                      "ex:name" nil}})
                    ;:headers {"X-Api-Version" "2"}
-                   :content-type       :json
-                   :socket-timeout     1000 ;; in milliseconds
-                   :connection-timeout 1000 ;; in milliseconds
-                   :accept             :json})
-     :body
-     (json/parse false))
-
- )
+                    :content-type       :json
+                    :socket-timeout     1000 ;; in milliseconds
+                    :connection-timeout 1000 ;; in milliseconds
+                    :accept             :json})
+      :body
+      (json/parse false)))

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -3,16 +3,15 @@
             [clojure.string :as str]
             [fluree.db.api :as fluree]
             [fluree.db.connection.system :as conn-system]
-            [fluree.server.handlers.transact :as tx-handler]
-            [fluree.server.handlers.create :as create-handler]
-            [fluree.server.consensus.raft.handler :as consensus-handler]
-            [fluree.server.consensus.raft]
-            [fluree.server.system :as system]
             [fluree.db.util.log :as log]
             [fluree.server.config :as config]
+            [fluree.server.consensus.raft]
+            [fluree.server.consensus.raft.handler :as consensus-handler]
+            [fluree.server.handlers.create :as create-handler]
+            [fluree.server.handlers.transact :as tx-handler]
+            [fluree.server.system :as system]
             [integrant.core :as ig]
             [integrant.repl :refer [clear go halt init reset reset-all]]))
-
 
 ;; Register dev-config as the default config
 (def sys-config (config/read-resource "file-config.jsonld"))

--- a/src/fluree/server/consensus/events.clj
+++ b/src/fluree/server/consensus/events.clj
@@ -76,3 +76,9 @@
 (defn error?
   [evt]
   (type? evt :error))
+
+(defn outcome?
+  [evt]
+  (or (transaction-committed? evt)
+      (ledger-created? evt)
+      (error? evt)))

--- a/src/fluree/server/consensus/raft/handlers/ledger_created.clj
+++ b/src/fluree/server/consensus/raft/handlers/ledger_created.clj
@@ -5,7 +5,7 @@
             [fluree.db.util.log :as log]
             [fluree.server.consensus.events :as events]
             [fluree.server.consensus.raft.handlers.new-commit :as new-commit]
-            [fluree.server.watcher :as watcher])
+            [fluree.server.consensus.response :as response])
   (:import (java.io File)))
 
 (set! *warn-on-reflection* true)
@@ -84,6 +84,5 @@
 
 (defn deliver!
   "Responsible for producing the event broadcast to connected peers."
-  [{:keys [fluree/watcher] :as _config} handler-result]
-  (let [new-ledger-event (events/ledger-created nil nil handler-result)]
-    (watcher/deliver-commit watcher nil nil new-ledger-event)))
+  [{:keys [fluree/watcher fluree/broadcaster] :as _config} {:keys [ledger-id tx-id] :as commit-result}]
+  (response/announce-new-ledger watcher broadcaster ledger-id tx-id commit-result))

--- a/src/fluree/server/consensus/raft/handlers/ledger_created.clj
+++ b/src/fluree/server/consensus/raft/handlers/ledger_created.clj
@@ -3,7 +3,6 @@
             [clojure.java.io :as io]
             [fluree.db.util.filesystem :as fs]
             [fluree.db.util.log :as log]
-            [fluree.server.consensus.events :as events]
             [fluree.server.consensus.raft.handlers.new-commit :as new-commit]
             [fluree.server.consensus.response :as response])
   (:import (java.io File)))

--- a/src/fluree/server/consensus/raft/handlers/new_commit.clj
+++ b/src/fluree/server/consensus/raft/handlers/new_commit.clj
@@ -8,7 +8,6 @@
             [fluree.db.util.filesystem :as fs]
             [fluree.db.util.json :as json]
             [fluree.db.util.log :as log]
-            [fluree.server.consensus.events :as events]
             [fluree.server.consensus.response :as response]))
 
 (set! *warn-on-reflection* true)

--- a/src/fluree/server/consensus/raft/handlers/new_commit.clj
+++ b/src/fluree/server/consensus/raft/handlers/new_commit.clj
@@ -9,7 +9,7 @@
             [fluree.db.util.json :as json]
             [fluree.db.util.log :as log]
             [fluree.server.consensus.events :as events]
-            [fluree.server.watcher :as watcher]))
+            [fluree.server.consensus.response :as response]))
 
 (set! *warn-on-reflection* true)
 
@@ -100,6 +100,6 @@
 
 (defn deliver!
   "Responsible for producing the event broadcast to connected peers."
-  [{:keys [fluree/watcher] :as _config} commit-result]
-  (let [new-commit-event (events/transaction-committed nil nil commit-result)]
-    (watcher/deliver-commit watcher nil nil new-commit-event)))
+  [{:keys [fluree/watcher fluree/broadcaster] :as _config}
+   {:keys [ledger-id tx-id] :as commit-result}]
+  (response/announce-commit watcher broadcaster ledger-id tx-id commit-result))

--- a/src/fluree/server/consensus/raft/handlers/tx_exception.clj
+++ b/src/fluree/server/consensus/raft/handlers/tx_exception.clj
@@ -1,6 +1,6 @@
 (ns fluree.server.consensus.raft.handlers.tx-exception
   (:require [fluree.db.util.log :as log]
-            [fluree.server.watcher :as watcher]))
+            [fluree.server.consensus.response :as response]))
 
 (defn update-ledger-state
   "Updates the latest commit in the ledger, and removes the processed transaction in the queue"
@@ -27,8 +27,8 @@
                  e)))))
 
 (defn deliver!
-  [{:keys [fluree/watcher] :as _config} exception]
-  (watcher/deliver-error watcher nil nil exception))
+  [{:keys [fluree/watcher fluree/broadcaster] :as _config} exception]
+  (response/announce-error watcher broadcaster nil nil exception))
 
 (defn handler
   "Handles transaction exceptions and broadcasts them to network."

--- a/src/fluree/server/consensus/response.clj
+++ b/src/fluree/server/consensus/response.clj
@@ -1,0 +1,25 @@
+(ns fluree.server.consensus.response
+  (:require [fluree.server.broadcast :as broadcast]
+            [fluree.server.consensus.events :as events]
+            [fluree.server.watcher :as watcher]))
+
+(defn announce-new-ledger
+  [watcher broadcaster ledger-id tx-id commit-result]
+  (let [new-ledger-event (events/ledger-created ledger-id tx-id commit-result)]
+    (broadcast/broadcast-new-ledger! broadcaster new-ledger-event)
+    (watcher/deliver-event watcher tx-id new-ledger-event)
+    ::new-ledger))
+
+(defn announce-commit
+  [watcher broadcaster ledger-id tx-id commit-result]
+  (let [commit-event (events/transaction-committed ledger-id tx-id commit-result)]
+    (broadcast/broadcast-new-commit! broadcaster commit-event)
+    (watcher/deliver-event watcher tx-id commit-event)
+    ::commit))
+
+(defn announce-error
+  [watcher broadcaster ledger-id tx-id ex]
+  (let [error-event (events/error ledger-id tx-id ex)]
+    (broadcast/broadcast-error! broadcaster error-event)
+    (watcher/deliver-event watcher tx-id error-event)
+    ::error))

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -6,8 +6,8 @@
             [fluree.db.util.core :refer [exception? get-first-value]]
             [fluree.db.util.log :as log]
             [fluree.server.consensus :as consensus]
-            [fluree.server.consensus.response :as response]
             [fluree.server.consensus.events :as events]
+            [fluree.server.consensus.response :as response]
             [fluree.server.handlers.shared :refer [deref!]]))
 
 (set! *warn-on-reflection* true)

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -6,9 +6,9 @@
             [fluree.db.util.core :refer [exception? get-first-value]]
             [fluree.db.util.log :as log]
             [fluree.server.consensus :as consensus]
+            [fluree.server.consensus.response :as response]
             [fluree.server.consensus.events :as events]
-            [fluree.server.handlers.shared :refer [deref!]]
-            [fluree.server.watcher :as watcher]))
+            [fluree.server.handlers.shared :refer [deref!]]))
 
 (set! *warn-on-reflection* true)
 
@@ -21,7 +21,7 @@
                {} string-opts)))
 
 (defn create-ledger!
-  [conn watcher {:keys [ledger-id tx-id txn opts] :as _params}]
+  [conn watcher broadcaster {:keys [ledger-id tx-id txn opts] :as _params}]
   (go-try
     (let [create-opts   (parse-opts txn)
           ledger        (deref!
@@ -31,10 +31,10 @@
                             (fluree/stage txn opts)
                             deref!)
           commit-result (deref! (fluree/apply-stage! ledger staged-db))]
-      (watcher/deliver-new-ledger watcher ledger-id tx-id commit-result))))
+      (response/announce-new-ledger watcher broadcaster ledger-id tx-id commit-result))))
 
 (defn transact!
-  [conn watcher {:keys [ledger-id tx-id txn opts] :as params}]
+  [conn watcher broadcaster {:keys [ledger-id tx-id txn opts] :as params}]
   (go-try
     (let [start-time    (System/currentTimeMillis)
           _             (log/debug "Starting transaction processing for ledger:" ledger-id
@@ -48,20 +48,20 @@
                             (fluree/stage txn opts)
                             deref!)
           commit-result (deref! (fluree/apply-stage! ledger staged-db))]
-      (watcher/deliver-commit watcher ledger-id tx-id commit-result))))
+      (response/announce-commit watcher broadcaster ledger-id tx-id commit-result))))
 
 (defn process-event
-  [conn watcher event]
+  [conn watcher broadcaster event]
   (go
     (try
       (let [event-type (events/event-type event)
             result     (<! (case event-type
-                             :ledger-create (create-ledger! conn watcher event)
-                             :tx-queue      (transact! conn watcher event)))]
+                             :ledger-create (create-ledger! conn watcher broadcaster event)
+                             :tx-queue      (transact! conn watcher broadcaster event)))]
         (if (exception? result)
           (let [{:keys [ledger-id tx-id]} event]
             (log/debug result "Delivering tx-exception to watcher")
-            (watcher/deliver-error watcher ledger-id tx-id result))
+            (response/announce-error watcher broadcaster ledger-id tx-id result))
           result))
       (catch Exception e
         (log/error e
@@ -75,9 +75,9 @@
       (nil? result)))
 
 (defn new-transaction-queue
-  ([conn watcher]
-   (new-transaction-queue conn watcher nil))
-  ([conn watcher max-pending-txns]
+  ([conn watcher broadcaster]
+   (new-transaction-queue conn watcher broadcaster nil))
+  ([conn watcher broadcaster max-pending-txns]
    (let [tx-queue (if (pos-int? max-pending-txns)
                     (async/chan max-pending-txns)
                     (async/chan))]
@@ -99,7 +99,7 @@
 
            :else
            (let [[event out-ch] input
-                 result         (<! (process-event conn watcher event))
+                 result         (<! (process-event conn watcher broadcaster event))
                  i*             (inc i)]
              (log/trace "Processed transaction #" i* ". Result:" result)
              (when-not (error? result)
@@ -134,8 +134,8 @@
       out-ch)))
 
 (defn start-buffered
-  [conn watcher max-pending-txns]
-  (let [tx-queue (new-transaction-queue conn watcher max-pending-txns)]
+  [conn watcher broadcaster max-pending-txns]
+  (let [tx-queue (new-transaction-queue conn watcher broadcaster max-pending-txns)]
     (->BufferedTransactor watcher tx-queue)))
 
 (defrecord SynchronizedTransactor [watcher tx-queue]
@@ -151,17 +151,17 @@
       out-ch)))
 
 (defn start-synchronized
-  [conn watcher]
-  (let [tx-queue (new-transaction-queue conn watcher)]
+  [conn watcher broadcaster]
+  (let [tx-queue (new-transaction-queue conn watcher broadcaster)]
     (->SynchronizedTransactor watcher tx-queue)))
 
 (defn start
-  ([conn watcher]
-   (start-synchronized conn watcher))
-  ([conn watcher max-pending-txns]
+  ([conn watcher broadcaster]
+   (start-synchronized conn watcher broadcaster))
+  ([conn watcher broadcaster max-pending-txns]
    (if max-pending-txns
-     (start-buffered conn watcher max-pending-txns)
-     (start-synchronized conn watcher))))
+     (start-buffered conn watcher broadcaster max-pending-txns)
+     (start-synchronized conn watcher broadcaster))))
 
 (defn stop
   [{:keys [tx-queue] :as _transactor}]

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -405,6 +405,7 @@
            :parameters {:body CreateRequestBody}
            :responses  {201 {:body CreateResponseBody}
                         400 {:body ErrorResponse}
+                        409 {:body ErrorResponse}
                         500 {:body ErrorResponse}}
            :handler    #'create/default}}])
 
@@ -414,6 +415,7 @@
            :parameters {:body TransactRequestBody}
            :responses  {200 {:body TransactResponseBody}
                         400 {:body ErrorResponse}
+                        409 {:body ErrorResponse}
                         500 {:body ErrorResponse}}
            :handler    #'srv-tx/default}}])
 

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -174,14 +174,13 @@
    :handler    #'ledger/history})
 
 (defn wrap-assoc-system
-  [conn consensus watcher subscriptions broadcaster handler]
+  [conn consensus watcher subscriptions handler]
   (fn [req]
     (-> req
         (assoc :fluree/conn conn
                :fluree/consensus consensus
                :fluree/watcher watcher
-               :fluree/subscriptions subscriptions
-               :fluree/broadcaster broadcaster)
+               :fluree/subscriptions subscriptions)
         handler)))
 
 (defn wrap-cors
@@ -372,9 +371,8 @@
          resp)))))
 
 (defn compose-app-middleware
-  [{:keys [connection consensus watcher subscriptions broadcaster
-           root-identities closed-mode]
-    :as _config}]
+  [{:keys [connection consensus watcher subscriptions root-identities closed-mode]
+    :as   _config}]
   (let [exception-middleware (exception/create-exception-middleware
                               (merge
                                exception/default-handlers
@@ -391,7 +389,7 @@
     (sort-middleware-by-weight [[1 exception-middleware]
                                 [10 wrap-cors]
                                 [10 (partial wrap-assoc-system connection consensus
-                                             watcher subscriptions broadcaster)]
+                                             watcher subscriptions)]
                                 [50 unwrap-credential]
                                 [100 wrap-set-fuel-header]
                                 [200 coercion/coerce-exceptions-middleware]

--- a/src/fluree/server/handlers/create.clj
+++ b/src/fluree/server/handlers/create.clj
@@ -19,12 +19,12 @@
     (monitor-consensus-persistence watcher ledger tx-id persist-resp-ch)))
 
 (defn create-ledger
-  [consensus watcher broadcaster ledger-id txn opts]
+  [consensus watcher ledger-id txn opts]
   (let [p         (promise)
         tx-id     (derive-tx-id txn)
         result-ch (watcher/create-watch watcher tx-id)]
     (queue-consensus consensus watcher ledger-id tx-id txn opts)
-    (monitor-commit p ledger-id tx-id broadcaster result-ch)
+    (monitor-commit p ledger-id tx-id result-ch)
     p))
 
 (defn throw-ledger-exists
@@ -35,13 +35,13 @@
                                 :body   {:error err-message}}}))))
 
 (defhandler default
-  [{:keys [fluree/conn fluree/consensus fluree/broadcaster fluree/watcher]
+  [{:keys [fluree/conn fluree/consensus fluree/watcher]
     {:keys [body]} :parameters}]
   (log/debug "create body:" body)
   (let [txn-context    (ctx-util/txn-context body)
         ledger-id      (transact-api/extract-ledger-id body)]
     (if-not (deref! (fluree/exists? conn ledger-id))
-      (let [resp-p (create-ledger consensus watcher broadcaster ledger-id body
+      (let [resp-p (create-ledger consensus watcher ledger-id body
                                   {:context txn-context})]
         {:status 201, :body (deref! resp-p)})
       (throw-ledger-exists ledger-id))))

--- a/src/fluree/server/handlers/shared.clj
+++ b/src/fluree/server/handlers/shared.clj
@@ -18,8 +18,11 @@
        (catch ExceptionInfo e#
          (if (-> e# ex-data (contains? :response))
            (throw e#)
-           (let [msg#   (ex-message e#)
-                 {status# :status :as data# :or {status# 500}} (ex-data e#)
+           (let [{status# :status
+                  :as     data#
+                  :or     {status# 500}} (ex-data e#)
+
+                 msg#   (ex-message e#)
                  error# (dissoc data# :status)]
              (throw (ex-info "Error in ledger handler"
                              {:response

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -28,7 +28,8 @@
       ;; check for exception trying to put txn in consensus, if so we must deliver the
       ;; watch here, but if successful the consensus process will deliver the watch downstream
       (when (util/exception? persist-resp)
-        (watcher/deliver-error watcher ledger tx-id persist-resp)))))
+        (let [error-event (events/error ledger tx-id persist-resp)]
+          (watcher/deliver-event watcher tx-id error-event))))))
 
 (defn queue-consensus
   "Register a new commit with consensus"

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -42,56 +42,48 @@
 (defn monitor-commit
   "Wait for final commit result from consensus on `result-ch`, broadcast to any
   subscribers and deliver response to promise `out-p`"
-  [out-p ledger-id tx-id broadcaster result-ch]
+  [out-p ledger-id tx-id result-ch]
   (go
     (let [result (async/<! result-ch)]
       (log/debug "HTTP API transaction final response: " result)
       (cond
         (= :timeout result)
-        (let [ex          (ex-info (str "Timeout waiting for transaction to complete for: "
-                                        ledger-id " with tx-id: " tx-id)
-                                   {:status 408, :error :db/response-timeout :tx-id tx-id})
-              error-event (events/error ledger-id tx-id ex)]
-          (broadcast/broadcast-error! broadcaster error-event)
+        (let [ex (ex-info (str "Timeout waiting for transaction to complete for: "
+                               ledger-id " with tx-id: " tx-id)
+                          {:status 408, :error :db/response-timeout :tx-id tx-id})]
           (deliver out-p ex))
 
         (nil? result)
-        (let [ex          (ex-info (str "Missing transaction result for ledger: "
-                                        ledger-id " with tx-id: " tx-id
-                                        ". Transaction may have processed, check ledger"
-                                        " for confirmation.")
-                                   {:status 500, :error :db/response-missing :tx-id tx-id})
-              error-event (events/error ledger-id tx-id ex)]
-          (broadcast/broadcast-error! broadcaster error-event)
+        (let [ex (ex-info (str "Missing transaction result for ledger: "
+                               ledger-id " with tx-id: " tx-id
+                               ". Transaction may have processed, check ledger"
+                               " for confirmation.")
+                          {:status 500, :error :db/response-missing :tx-id tx-id})]
           (deliver out-p ex))
 
         (util/exception? result)
-        (let [error-event (events/error ledger-id tx-id result)]
-          (broadcast/broadcast-error! broadcaster error-event)
-          (deliver out-p result))
+        (deliver out-p result)
 
         (events/error? result)
         (let [ex (:error result)]
-          (broadcast/broadcast-error! broadcaster result)
           (deliver out-p ex))
 
         :else
         (let [{:keys [ledger-id commit t tx-id]} result]
           (log/info "Transaction completed for:" ledger-id "tx-id:" tx-id
                     "commit head:" commit)
-          (broadcast/broadcast-event! broadcaster result)
           (deliver out-p {:ledger ledger-id
                           :commit commit
                           :t      t
                           :tx-id  tx-id}))))))
 
 (defn transact!
-  [consensus watcher broadcaster ledger-id txn opts]
+  [consensus watcher ledger-id txn opts]
   (let [p         (promise)
         tx-id     (derive-tx-id txn)
         result-ch (watcher/create-watch watcher tx-id)]
     (queue-consensus consensus watcher ledger-id tx-id txn opts)
-    (monitor-commit p ledger-id tx-id broadcaster result-ch)
+    (monitor-commit p ledger-id tx-id result-ch)
     p))
 
 (defn throw-ledger-doesnt-exist
@@ -102,13 +94,13 @@
                                 :body   {:error err-message}}}))))
 
 (defhandler default
-  [{:keys [fluree/conn fluree/consensus fluree/watcher fluree/broadcaster credential/did raw-txn]
+  [{:keys [fluree/conn fluree/consensus fluree/watcher credential/did raw-txn]
     {:keys [body]} :parameters}]
   (let [txn-context    (ctx-util/txn-context body)
         ledger-id      (transact-api/extract-ledger-id body)]
     (if (deref! (fluree/exists? conn ledger-id))
       (let [opts   (cond-> {:context txn-context :raw-txn raw-txn}
                      did (assoc :did did))
-            resp-p (transact! consensus watcher broadcaster ledger-id body opts)]
+            resp-p (transact! consensus watcher ledger-id body opts)]
         {:status 200, :body (deref! resp-p)})
       (throw-ledger-doesnt-exist ledger-id))))

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -7,7 +7,6 @@
             [fluree.db.util.core :as util]
             [fluree.db.util.log :as log]
             [fluree.json-ld :as json-ld]
-            [fluree.server.broadcast :as broadcast]
             [fluree.server.consensus :as consensus]
             [fluree.server.consensus.events :as events]
             [fluree.server.handlers.shared :refer [defhandler deref!]]

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -50,7 +50,10 @@
         (= :timeout result)
         (let [ex (ex-info (str "Timeout waiting for transaction to complete for: "
                                ledger-id " with tx-id: " tx-id)
-                          {:status 408, :error :db/response-timeout :tx-id tx-id})]
+                          {:status 408
+                           :error  :db/response-timeout
+                           :ledger ledger-id
+                           :tx-id  tx-id})]
           (deliver out-p ex))
 
         (nil? result)
@@ -58,7 +61,10 @@
                                ledger-id " with tx-id: " tx-id
                                ". Transaction may have processed, check ledger"
                                " for confirmation.")
-                          {:status 500, :error :db/response-missing :tx-id tx-id})]
+                          {:status 500
+                           :error  :db/response-missing
+                           :ledger ledger-id
+                           :tx-id  tx-id})]
           (deliver out-p ex))
 
         (util/exception? result)

--- a/src/fluree/server/system.clj
+++ b/src/fluree/server/system.clj
@@ -41,8 +41,7 @@
                        :connection      (ig/ref ::db/connection)
                        :consensus       (ig/ref ::server/consensus)
                        :watcher         (ig/ref ::server/watcher)
-                       :subscriptions   (ig/ref ::server/subscriptions)
-                       :broadcaster     (ig/ref ::server/broadcast)}}))
+                       :subscriptions   (ig/ref ::server/subscriptions)}}))
 
 (defmethod ig/expand-key ::consensus/standalone
   [k config]
@@ -100,8 +99,7 @@
 (defmethod ig/init-key ::server/handler
   [_ config]
   (-> config
-      (select-keys [:connection :consensus :watcher :subscriptions :broadcaster :root-identities
-                    :closed-mode])
+      (select-keys [:connection :consensus :watcher :subscriptions :root-identities :closed-mode])
       handler/app))
 
 (defmethod ig/init-key ::http/jetty

--- a/src/fluree/server/system.clj
+++ b/src/fluree/server/system.clj
@@ -45,7 +45,9 @@
 
 (defmethod ig/expand-key ::consensus/standalone
   [k config]
-  {k (assoc config :watcher (ig/ref ::server/watcher))})
+  {k (assoc config
+            :watcher (ig/ref ::server/watcher)
+            :broadcaster (ig/ref ::server/broadcast))})
 
 (defmethod ig/init-key ::server/subscriptions
   [_ _]
@@ -87,10 +89,10 @@
   (close))
 
 (defmethod ig/init-key ::consensus/standalone
-  [_ {:keys [watcher] :as config}]
+  [_ {:keys [watcher broadcaster] :as config}]
   (let [max-pending-txns (conn-config/get-first-integer config server-vocab/max-pending-txns)
         conn             (get-first config conn-vocab/connection)]
-    (standalone/start conn watcher max-pending-txns)))
+    (standalone/start conn watcher broadcaster max-pending-txns)))
 
 (defmethod ig/halt-key! ::consensus/standalone
   [_ transactor]

--- a/src/fluree/server/watcher.clj
+++ b/src/fluree/server/watcher.clj
@@ -7,8 +7,7 @@
   responsible server from a queue, processed, and then the results broadcast
   back out."
   (:require [clojure.core.async :as async :refer [<! go]]
-            [fluree.db.util.log :as log]
-            [fluree.server.consensus.events :as events]))
+            [fluree.db.util.log :as log]))
 
 (set! *warn-on-reflection* true)
 
@@ -64,21 +63,6 @@
     ;; note: this can have a race condition, but given it is a promise chan, the
     ;; second put! will be ignored
     (swap! state deliver-event-state id event)))
-
-(defn deliver-new-ledger
-  [w ledger-id tx-id commit-result]
-  (let [new-ledger-event (events/ledger-created ledger-id tx-id commit-result)]
-    (deliver-event w tx-id new-ledger-event)))
-
-(defn deliver-commit
-  [w ledger-id tx-id commit-result]
-  (let [commit-event (events/transaction-committed ledger-id tx-id commit-result)]
-    (deliver-event w tx-id commit-event)))
-
-(defn deliver-error
-  [w ledger-id tx-id ex]
-  (let [error-event (events/error ledger-id tx-id ex)]
-    (deliver-event w tx-id error-event)))
 
 (defn start
   ([]

--- a/src/fluree/server/watcher.clj
+++ b/src/fluree/server/watcher.clj
@@ -15,7 +15,7 @@
 (defprotocol Watcher
   (create-watch [w id])
   (watching? [w id])
-  (-deliver-event [w id event]))
+  (deliver-event [w id event]))
 
 (defn new-watcher-atom
   "This atom maps a request's unique id (e.g. tx-id) to a promise that will be
@@ -60,7 +60,7 @@
     (create-watch-state state max-txn-wait-ms id))
   (watching? [_ id]
     (contains? @state id))
-  (-deliver-event [_ id event]
+  (deliver-event [_ id event]
     ;; note: this can have a race condition, but given it is a promise chan, the
     ;; second put! will be ignored
     (swap! state deliver-event-state id event)))
@@ -68,17 +68,17 @@
 (defn deliver-new-ledger
   [w ledger-id tx-id commit-result]
   (let [new-ledger-event (events/ledger-created ledger-id tx-id commit-result)]
-    (-deliver-event w tx-id new-ledger-event)))
+    (deliver-event w tx-id new-ledger-event)))
 
 (defn deliver-commit
   [w ledger-id tx-id commit-result]
   (let [commit-event (events/transaction-committed ledger-id tx-id commit-result)]
-    (-deliver-event w tx-id commit-event)))
+    (deliver-event w tx-id commit-event)))
 
 (defn deliver-error
   [w ledger-id tx-id ex]
   (let [error-event (events/error ledger-id tx-id ex)]
-    (-deliver-event w tx-id error-event)))
+    (deliver-event w tx-id error-event)))
 
 (defn start
   ([]


### PR DESCRIPTION
This patch changes the responsibility of broadcasting a new commit (back) to the transactor instead of the requesting server/process. There was the same amount of complexity to communicate the new transaction back to the requesting process as there would have been to broadcast the message in the first place, plus the extra complexity to broadcast the message out from the requesting process.

This patch also simplifies the broadcast and watcher apis to use generic events, and has some cleanup and cljfmt fixes.