### PR TITLE
Save transactions and track metadata

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "550b427e93b5b2ac292831ec55623f65caada507"}
+                                :git/sha "32e41cac83278a25fc428937bd922cfef0a71843"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,8 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
-        com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "923ab4dffd3b70ab4c1a2a025769feb39af532a8"}
+        ;; com.fluree/db          {:git/url "https://github.com/fluree/db.git"
+        ;;                         :git/sha "923ab4dffd3b70ab4c1a2a025769feb39af532a8"}
+        com.fluree/db {:local/root "../db"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
-        ;; com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-        ;;                         :git/sha "923ab4dffd3b70ab4c1a2a025769feb39af532a8"}
-        com.fluree/db {:local/root "../db"}
+        com.fluree/db          {:git/url "https://github.com/fluree/db.git"
+                                :git/sha "dca1e35afb8b84f557d84b27f0dd387064626012"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -42,6 +42,7 @@
                          (<? (events/resolve-txn conn event))
                          event)
             event-type (events/event-type event*)]
+        (log/info "Standalone transactor processing event:" event "transalted:" event*)
         (cond
           (= :ledger-create event-type)
           (<? (create-ledger! conn watcher broadcaster event*))

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -39,7 +39,7 @@
   (go
     (try
       (let [event*     (if (events/resolve-txn? event)
-                         (<? (events/resolve-txn conn event))
+                         (<? (events/resolve-txns conn event))
                          event)
             event-type (events/event-type event*)]
         (cond

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -42,7 +42,6 @@
                          (<? (events/resolve-txn conn event))
                          event)
             event-type (events/event-type event*)]
-        (log/info "Standalone transactor processing event:" event "transalted:" event*)
         (cond
           (= :ledger-create event-type)
           (<? (create-ledger! conn watcher broadcaster event*))

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -270,16 +270,6 @@
 (def wrap-set-policy-header
   (partial set-track-header ::track/policy))
 
-(defn wrap-set-policy-header
-  [handler]
-  (fn [req]
-    (let [resp (handler req)]
-      (if-let [policy (-> resp :body ::track/policy)]
-        (-> resp
-            (assoc-in [:headers "x-fdb-policy"] policy)
-            (update :body dissoc ::track/policy))
-        resp))))
-
 (def fluree-header-keys
   ["fluree-track-meta" "fluree-max-fuel" "fluree-identity" "fluree-policy-identity"
    "fluree-policy" "fluree-policy-class" "fluree-policy-values" "fluree-format"

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -226,7 +226,10 @@
             (throw (ex-info "Invalid credential"
                             {:response {:status 400
                                         :body   {:error "Invalid credential"}}})))
-          req*     (assoc req :body-params subject :credential/did did :raw-txn body-params)]
+          req*     (assoc req
+                          :body-params subject
+                          :credential/did did
+                          :raw-txn body-params)]
       (log/debug "Unwrapped credential with did:" did)
       (handler req*))))
 

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -273,7 +273,8 @@
 (def fluree-header-keys
   ["fluree-track-meta" "fluree-max-fuel" "fluree-identity" "fluree-policy-identity"
    "fluree-policy" "fluree-policy-class" "fluree-policy-values" "fluree-format"
-   "fluree-output" "fluree-track-fuel" "fluree-track-policy" "fluree-track-file"])
+   "fluree-output" "fluree-track-fuel" "fluree-track-policy" "fluree-track-file"
+   "fluree-ledger"])
 
 (defn parse-boolean-header
   [header name]
@@ -291,7 +292,7 @@
   (fn [{:keys [headers credential/did] :as req}]
     (let [prefix-count (count "fluree-")
           {:keys [track-meta max-fuel track-fuel track-file identity policy-identity
-                  policy policy-class policy-values track-policy format output]}
+                  policy policy-class policy-values track-policy format output ledger]}
           (-> headers
               (select-keys fluree-header-keys)
               (update-keys (fn [k] (keyword (subs k prefix-count)))))
@@ -355,6 +356,7 @@
                  max-fuel      (assoc :max-fuel max-fuel)
                  format        (assoc :format format)
                  output        (assoc :output output)
+                 ledger        (assoc :ledger ledger)
                  policy        (assoc :policy policy)
                  policy-class  (assoc :policy-class policy-class)
                  policy-values (assoc :policy-values policy-values)

--- a/src/fluree/server/handlers/create.clj
+++ b/src/fluree/server/handlers/create.clj
@@ -31,6 +31,7 @@
     {:keys [body]} :parameters}]
   (log/debug "create body:" body)
   (let [txn       (fluree/format-txn body opts)
-        ledger-id (extract-ledger-id txn)
+        ledger-id (or (:ledger opts)
+                      (extract-ledger-id txn))
         resp-p    (create-ledger consensus watcher ledger-id txn {})]
     {:status 201, :body (deref! resp-p)}))

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -103,7 +103,8 @@
   [{:keys          [fluree/consensus fluree/watcher credential/did fluree/opts raw-txn]
     {:keys [body]} :parameters}]
   (let [txn       (fluree/format-txn body opts)
-        ledger-id (extract-ledger-id txn)
+        ledger-id (or (:ledger opts)
+                      (extract-ledger-id txn))
         opts*     (cond-> (assoc opts :format :fql)
                     raw-txn (assoc :raw-txn raw-txn)
                     did     (assoc :did did))

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -14,10 +14,10 @@
 (set! *warn-on-reflection* true)
 
 (defn derive-tx-id
-  [raw-txn]
-  (if (string? raw-txn)
-    (crypto/sha2-256 raw-txn :hex :string)
-    (-> (json-ld/normalize-data raw-txn)
+  [txn]
+  (if (string? txn)
+    (crypto/sha2-256 txn :hex :string)
+    (-> (json-ld/normalize-data txn)
         (crypto/sha2-256 :hex :string))))
 
 (defn monitor-consensus-persistence
@@ -104,7 +104,8 @@
     {:keys [body]} :parameters}]
   (let [txn       (fluree/format-txn body opts)
         ledger-id (extract-ledger-id txn)
-        opts*     (cond-> (assoc opts :raw-txn raw-txn, :format :fql)
-                    did (assoc :did did))
+        opts*     (cond-> (assoc opts :format :fql)
+                    raw-txn (assoc :raw-txn raw-txn)
+                    did     (assoc :did did))
         resp-p    (transact! consensus watcher ledger-id txn opts*)]
     {:status 200, :body (deref! resp-p)}))

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -76,8 +76,8 @@
 
         :else
         (let [{:keys [ledger-id commit t tx-id]} result]
-          (log/info "Transaction completed for:" ledger-id "tx-id:" tx-id
-                    "commit head:" commit)
+          (log/debug "Transaction completed for:" ledger-id "tx-id:" tx-id
+                     "commit head:" commit)
           (deliver out-p {:ledger ledger-id
                           :commit commit
                           :t      t

--- a/test/fluree/server/integration/sparql_test.clj
+++ b/test/fluree/server/integration/sparql_test.clj
@@ -33,7 +33,7 @@
 
           meta-res    (api-post :query {:body    query
                                         :headers (assoc sparql-results-headers
-                                                        "Fluree-Meta" true)})
+                                                        "Fluree-Track-Meta" true)})
 
           construct   (str "PREFIX ex: <http://example.org/>
                             PREFIX schema: <http://schema.org/>


### PR DESCRIPTION
This patch allows users and library consumers to create consensus events with either a transaction document or transaction address so that library consumers can choose to save transactions before pushing them through consensus. Related to that, the standalone transactor will now read transactions from storage if the consensus events it receives only specifies an address instead of the transaction document. Lastly, this patch sets metadata response headers for both fuel and policy report if those values are in the response.