### PR TITLE
Fix/datafy error

### DIFF
--- a/src/fluree/server/consensus/events.clj
+++ b/src/fluree/server/consensus/events.clj
@@ -176,7 +176,6 @@
    (-> {:type          :error
         :ledger-id     ledger-id
         :tx-id         tx-id
-        :error         exception
         :error-message (ex-message exception)
         :error-data    (ex-data exception)}))
   ([processing-server ledger-id tx-id exception]

--- a/src/fluree/server/consensus/events.clj
+++ b/src/fluree/server/consensus/events.clj
@@ -176,7 +176,7 @@
    (-> {:type          :error
         :ledger-id     ledger-id
         :tx-id         tx-id
-        :error         exception
+        :error         (Throwable->map exception)
         :error-message (ex-message exception)
         :error-data    (ex-data exception)}))
   ([processing-server ledger-id tx-id exception]

--- a/src/fluree/server/consensus/events.clj
+++ b/src/fluree/server/consensus/events.clj
@@ -176,7 +176,7 @@
    (-> {:type          :error
         :ledger-id     ledger-id
         :tx-id         tx-id
-        :error         (Throwable->map exception)
+        :error         exception
         :error-message (ex-message exception)
         :error-data    (ex-data exception)}))
   ([processing-server ledger-id tx-id exception]

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -50,14 +50,12 @@
           (<? (transact! conn watcher broadcaster event*))
 
           :else
-          (do (log/error "Unexpected event message - expected a map with a supported "
-                         "event type. Received:" event*)
-              (throw (ex-info (str "Unexpected event message: event type '" event-type "' not"
-                                   " one of (':ledger-create', ':tx-queue')")
-                              {:status 500, :error :consensus/unexpected-event})))))
+          (throw (ex-info (str "Unexpected event message: event type '" event-type "' not"
+                               " one of (':ledger-create', ':tx-queue')")
+                          {:status 500, :error :consensus/unexpected-event}))))
       (catch Exception e
         (let [{:keys [ledger-id tx-id]} event]
-          (log/debug e "Delivering tx-exception to watcher")
+          (log/warn e "Error processing consensus event")
           (response/announce-error watcher broadcaster ledger-id tx-id e))))))
 
 (defn error?

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -265,10 +265,10 @@
         resp))))
 
 (def wrap-set-fuel-header
-  (partial set-track-header ::track/fuel))
+  (partial set-track-header :fuel))
 
 (def wrap-set-policy-header
-  (partial set-track-header ::track/policy))
+  (partial set-track-header :policy))
 
 (def fluree-header-keys
   ["fluree-track-meta" "fluree-max-fuel" "fluree-identity" "fluree-policy-identity"

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -28,6 +28,7 @@
       ;; deliver the watch here, but if successful the consensus process will
       ;; deliver the watch downstream
       (when (util/exception? persist-resp)
+        (log/warn persist-resp "Error submitting transaction")
         (let [error-event (events/error ledger tx-id persist-resp)]
           (watcher/deliver-event watcher tx-id error-event))))))
 
@@ -71,7 +72,7 @@
         (deliver out-p result)
 
         (events/error? result)
-        (let [ex (:error result)]
+        (let [ex (ex-info (:error-message result) (:error-data result))]
           (deliver out-p ex))
 
         :else

--- a/test/fluree/server/integration/sparql_test.clj
+++ b/test/fluree/server/integration/sparql_test.clj
@@ -52,14 +52,14 @@
              (-> query-res :body json/read-value)))
 
       (is (= 200 (:status meta-res)))
-      (is (= {"fuel" 2,
-              "status" 200,
+      (is (= {"status" 200,
               "result"
               {"results"
                {"bindings"
                 [{"name" {"value" "query-sparql-test", "type" "literal"}}]},
                "head" {"vars" ["name"]}}}
              (-> meta-res :body json/read-value (dissoc "time"))))
+      (is (= 2 (-> meta-res :headers (get "x-fdb-fuel") Integer/parseInt)))
       (is (= 200 (:status rdf-res)))
       (is (= {"@context" {"ex" "http://example.org/" "schema" "http://schema.org/"},
               "@graph" [{"@id" "ex:query-sparql-test"


### PR DESCRIPTION
This patch makes consensus messages indicating errors more general by allowing them to be transmitted across the network. It removes the literal exception object from the message and makes receivers reconstruct the exception as necessary from the data within the message.