### PR TITLE
Set tracking response headers

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "dca1e35afb8b84f557d84b27f0dd387064626012"}
+                                :git/sha "36e3641de1c380af471adcd3d59d1364f0d34e36"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "f273e142fd8d541c7293e1340c16c683b9e63132"}
+                                :git/sha "9d7a3886702a39b9d09983b261228f7c14349f36"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "9d7a3886702a39b9d09983b261228f7c14349f36"}
+                                :git/sha "c5c999cbc808b6b7429c08b91fcf3fd3d5ee76f6"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "36e3641de1c380af471adcd3d59d1364f0d34e36"}
+                                :git/sha "f273e142fd8d541c7293e1340c16c683b9e63132"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 

--- a/dev/src/benchmark.clj
+++ b/dev/src/benchmark.clj
@@ -2,11 +2,11 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.test :refer [is testing]]
+            [fluree.db.util.json :as json]
             [fluree.server.integration.test-system
              :refer [api-post create-rand-ledger json-headers set-server-ports api-port]
              :as test-system]
-            [fluree.server.system :as system]
-            [fluree.db.util.json :as json])
+            [fluree.server.system :as system])
   (:import (java.time Instant)))
 
 (def ^:private mb-size (* 1024 1024)) ; 1 MB in bytes

--- a/dev/src/benchmark.clj
+++ b/dev/src/benchmark.clj
@@ -6,7 +6,7 @@
              :refer [api-post create-rand-ledger json-headers set-server-ports api-port]
              :as test-system]
             [fluree.server.system :as system]
-            [jsonista.core :as json])
+            [fluree.db.util.json :as json])
   (:import (java.time Instant)))
 
 (def ^:private mb-size (* 1024 1024)) ; 1 MB in bytes
@@ -33,9 +33,7 @@
   "Runs all benchmark tests with the specified configuration file."
   [config-file run-tests]
   (set-server-ports)
-  (let [config (-> (io/resource config-file)
-                   slurp
-                   json/read-value)
+  (let [config (-> config-file io/resource slurp (json/parse false))
         ; Find the API server config and update its port
         updated-port-config (update config "@graph"
                                     (fn [nodes]
@@ -120,8 +118,9 @@
                        (for [batch (range num-batches)]
                          (let [batch-data (generate-transaction-data batch-size-mb)
                                _         (println (format "Processing batch %d of %.0f" (inc batch) num-batches))
-                               req      (json/write-value-as-string
-                                         (assoc batch-data "ledger" ledger-name))
+                               req      (-> batch-data
+                                            (assoc :ledger ledger-name)
+                                            json/stringify)
                                res      (api-post :transact {:body req :headers json-headers})]
                            (when-not (= 200 (:status res))
                              (throw (ex-info "Transaction failed"

--- a/src/fluree/server/consensus/events.clj
+++ b/src/fluree/server/consensus/events.clj
@@ -149,8 +149,8 @@
             :tx-id     tx-id
             :commit    {:address address
                         :hash    hash}}
-     fuel   (assoc ::track/fuel fuel)
-     policy (assoc ::track/policy policy)))
+     fuel   (assoc :fuel fuel)
+     policy (assoc :policy policy)))
   ([processing-server ledger-id tx-id commit-result]
    (-> (transaction-committed ledger-id tx-id commit-result)
        (assoc :server processing-server))))

--- a/src/fluree/server/consensus/events.clj
+++ b/src/fluree/server/consensus/events.clj
@@ -142,13 +142,14 @@
 (defn transaction-committed
   "Post-transaction, the message we will broadcast out and/or deliver
   to a client awaiting a response."
-  ([ledger-id tx-id {:keys [db address hash fuel policy] :as _commit-result}]
+  ([ledger-id tx-id {:keys [db address hash fuel policy time] :as _commit-result}]
    (cond-> {:type      :transaction-committed
             :ledger-id ledger-id
             :t         (:t db)
             :tx-id     tx-id
             :commit    {:address address
                         :hash    hash}}
+     time   (assoc :time time)
      fuel   (assoc :fuel fuel)
      policy (assoc :policy policy)))
   ([processing-server ledger-id tx-id commit-result]

--- a/src/fluree/server/consensus/standalone.clj
+++ b/src/fluree/server/consensus/standalone.clj
@@ -10,17 +10,10 @@
 
 (set! *warn-on-reflection* true)
 
-(defn ensure-file-reports
-  [meta]
-  (if (true? meta)
-    meta
-    (assoc meta :file true)))
-
 (defn create-ledger!
   [conn watcher broadcaster {:keys [ledger-id tx-id txn opts] :as _params}]
   (go-try
-    (let [opts*         (update opts :meta ensure-file-reports)
-          commit-result (deref! (fluree/create-with-txn conn txn opts*))]
+    (let [commit-result (deref! (fluree/create-with-txn conn txn opts))]
       (response/announce-new-ledger watcher broadcaster ledger-id tx-id commit-result))))
 
 (defn transact!
@@ -30,8 +23,7 @@
           _             (log/debug "Starting transaction processing for ledger:" ledger-id
                                    "with tx-id" tx-id ". Transaction sat in queue for"
                                    (- start-time (:instant params)) "milliseconds.")
-          opts*         (update opts :meta ensure-file-reports)
-          commit-result (deref! (fluree/transact! conn txn opts*))]
+          commit-result (deref! (fluree/transact! conn txn opts))]
       (response/announce-commit watcher broadcaster ledger-id tx-id commit-result))))
 
 (defn process-event

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -337,6 +337,7 @@
                        (= format "sparql") :sparql
                        (= output "fql")    :fql
                        :else               :fql)
+
           policy        (when policy
                           (try (json/parse policy false)
                                (catch Exception _

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -4,7 +4,6 @@
             [fluree.db.json-ld.credential :as cred]
             [fluree.db.query.fql.syntax :as fql]
             [fluree.db.query.history.parse :as fqh]
-            [fluree.db.track :as-alias track]
             [fluree.db.util.json :as json]
             [fluree.db.util.log :as log]
             [fluree.db.validation :as v]
@@ -274,10 +273,9 @@
   (partial set-track-response-header :time))
 
 (def fluree-request-header-keys
-  ["fluree-track-meta" "fluree-track-time" "fluree-track-fuel" "fluree-track-policy"
-   "fluree-ledger" "fluree-max-fuel" "fluree-identity" "fluree-policy-identity"
-   "fluree-policy" "fluree-policy-class" "fluree-policy-values" "fluree-format"
-   "fluree-output"])
+  ["fluree-track-meta" "fluree-track-fuel" "fluree-track-policy" "fluree-ledger"
+   "fluree-max-fuel" "fluree-identity" "fluree-policy-identity" "fluree-policy"
+   "fluree-policy-class" "fluree-policy-values" "fluree-format" "fluree-output"])
 
 (defn parse-boolean-header
   [header name]
@@ -296,7 +294,7 @@
   transaction or query."
   [handler]
   (fn [{:keys [headers credential/did] :as req}]
-    (let [{:keys [track-meta track-time track-fuel track-policy max-fuel
+    (let [{:keys [track-meta track-fuel track-policy max-fuel
                   identity policy-identity policy policy-class policy-values
                   format output ledger]}
           (-> headers
@@ -310,9 +308,9 @@
                                                 {:status 400, :error :server/invalid-header}
                                                 e)))))
           track-meta   (some-> track-meta (parse-boolean-header "track-meta"))
-          track-time   (some-> track-time (parse-boolean-header "track-time"))
           track-policy (some-> track-policy (parse-boolean-header "track-policy"))
           track-fuel   (some-> track-fuel (parse-boolean-header "track-fuel"))
+          track-time   true
           track-file   true ; File tracking is required for consensus components
           meta         (if track-meta
                          (if (and track-time track-fuel track-policy track-file)

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -311,8 +311,8 @@
                                                 e)))))
           track-meta   (some-> track-meta (parse-boolean-header "track-meta"))
           track-time   (some-> track-time (parse-boolean-header "track-time"))
-          track-fuel   (some-> track-fuel (parse-boolean-header "track-fuel"))
           track-policy (some-> track-policy (parse-boolean-header "track-policy"))
+          track-fuel   (some-> track-fuel (parse-boolean-header "track-fuel"))
           track-file   true ; File tracking is required for consensus components
           meta         (if track-meta
                          (if (and track-time track-fuel track-policy track-file)
@@ -459,13 +459,13 @@
                                 [10 (partial wrap-assoc-system connection consensus
                                              watcher subscriptions)]
                                 [50 unwrap-credential]
-                                [100 wrap-set-fuel-response-header]
-                                [105 wrap-set-policy-response-header]
-                                [110 wrap-set-time-response-header]
                                 [200 coercion/coerce-exceptions-middleware]
                                 [300 coercion/coerce-response-middleware]
                                 [400 coercion/coerce-request-middleware]
                                 [500 wrap-request-header-opts]
+                                [505 wrap-set-fuel-response-header]
+                                [510 wrap-set-policy-response-header]
+                                [515 wrap-set-time-response-header]
                                 [600 (wrap-closed-mode root-identities closed-mode)]
                                 [1000 exception-middleware]])))
 

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -252,26 +252,6 @@
                   (handler req*))))
         (handler req)))))
 
-(defn set-track-response-header
-  [track-opt handler]
-  (fn [req]
-    (let [resp (handler req)]
-      (if-let [header-val (-> resp :body (get track-opt))]
-        (let [opt-name (str "x-fdb-" (name track-opt))]
-          (-> resp
-              (assoc-in [:headers opt-name] (str header-val))
-              (update :body dissoc track-opt)))
-        resp))))
-
-(def wrap-set-fuel-response-header
-  (partial set-track-response-header :fuel))
-
-(def wrap-set-policy-response-header
-  (partial set-track-response-header :policy))
-
-(def wrap-set-time-response-header
-  (partial set-track-response-header :time))
-
 (def fluree-request-header-keys
   ["fluree-track-meta" "fluree-track-fuel" "fluree-track-policy" "fluree-ledger"
    "fluree-max-fuel" "fluree-identity" "fluree-policy-identity" "fluree-policy"
@@ -461,9 +441,6 @@
                                 [300 coercion/coerce-response-middleware]
                                 [400 coercion/coerce-request-middleware]
                                 [500 wrap-request-header-opts]
-                                [505 wrap-set-fuel-response-header]
-                                [510 wrap-set-policy-response-header]
-                                [515 wrap-set-time-response-header]
                                 [600 (wrap-closed-mode root-identities closed-mode)]
                                 [1000 exception-middleware]])))
 

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -273,7 +273,8 @@
 (def fluree-header-keys
   ["fluree-track-meta" "fluree-max-fuel" "fluree-identity" "fluree-policy-identity"
    "fluree-policy" "fluree-policy-class" "fluree-policy-values" "fluree-format"
-   "fluree-output" "fluree-track-fuel" "fluree-track-policy" "fluree-ledger"])
+   "fluree-output" "fluree-track-time" "fluree-track-fuel" "fluree-track-policy"
+   "fluree-ledger"])
 
 (defn parse-boolean-header
   [header name]
@@ -305,18 +306,21 @@
                                                 {:status 400, :error :server/invalid-header}
                                                 e)))))
           track-meta   (some-> track-meta (parse-boolean-header "track-meta"))
+          track-time   (some-> track-meta (parse-boolean-header "track-time"))
           track-fuel   (some-> track-fuel (parse-boolean-header "track-fuel"))
           track-policy (some-> track-policy (parse-boolean-header "track-policy"))
           track-file   true ; File tracking is required for consensus components
           meta         (if track-meta
-                         (if (and track-fuel track-policy track-file)
+                         (if (and track-time track-fuel track-policy track-file)
                            true
                            (cond-> {}
+                             (not (false? track-time))   (assoc :time true)
                              (not (false? track-fuel))   (assoc :fuel true)
                              (not (false? track-policy)) (assoc :policy true)
                              (not (false? track-file))   (assoc :file true)
                              true                        not-empty))
                          (cond-> {}
+                           track-time   (assoc :time true)
                            track-fuel   (assoc :fuel true)
                            track-policy (assoc :policy true)
                            track-file   (assoc :file true)

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -367,7 +367,9 @@
                  identity        (assoc :identity identity)
                  ;; credential (signed) identity overrides all else
                  did             (assoc :identity did))]
-      (handler (assoc req :fluree/opts opts)))))
+      (-> req
+          (assoc :fluree/opts opts)
+          handler))))
 
 (defn sort-middleware-by-weight
   [weighted-middleware]

--- a/src/fluree/server/handlers/create.clj
+++ b/src/fluree/server/handlers/create.clj
@@ -33,5 +33,6 @@
   (let [txn       (fluree/format-txn body opts)
         ledger-id (or (:ledger opts)
                       (extract-ledger-id txn))
-        resp-p    (create-ledger consensus watcher ledger-id txn {})]
+        opts*     (dissoc opts :identity opts) ; FIXME
+        resp-p    (create-ledger consensus watcher ledger-id txn opts*)]
     {:status 201, :body (deref! resp-p)}))

--- a/src/fluree/server/handlers/create.clj
+++ b/src/fluree/server/handlers/create.clj
@@ -17,7 +17,7 @@
         persist-resp-ch (consensus/queue-new-ledger consensus ledger tx-id txn opts)]
     (monitor-consensus-persistence watcher ledger tx-id persist-resp-ch)))
 
-(defn create-ledger
+(defn create-ledger!
   [consensus watcher ledger-id txn opts]
   (let [p         (promise)
         tx-id     (derive-tx-id txn)
@@ -38,5 +38,5 @@
                                           ; upstream, and there are no policies
                                           ; in an empty ledger to allow any
                                           ; actions
-        resp-p    (create-ledger consensus watcher ledger-id txn opts*)]
+        resp-p    (create-ledger! consensus watcher ledger-id txn opts*)]
     {:status 201, :body (deref! resp-p)}))

--- a/src/fluree/server/handlers/create.clj
+++ b/src/fluree/server/handlers/create.clj
@@ -33,5 +33,10 @@
   (let [txn       (fluree/format-txn body opts)
         ledger-id (or (:ledger opts)
                       (extract-ledger-id txn))
-        resp-p    (create-ledger consensus watcher ledger-id txn opts)]
+        opts*     (dissoc opts :identity) ; Remove identity option because the
+                                          ; request should have been validated
+                                          ; upstream, and there are no policies
+                                          ; in an empty ledger to allow any
+                                          ; actions
+        resp-p    (create-ledger consensus watcher ledger-id txn opts*)]
     {:status 201, :body (deref! resp-p)}))

--- a/src/fluree/server/handlers/create.clj
+++ b/src/fluree/server/handlers/create.clj
@@ -33,6 +33,5 @@
   (let [txn       (fluree/format-txn body opts)
         ledger-id (or (:ledger opts)
                       (extract-ledger-id txn))
-        opts*     (dissoc opts :identity opts) ; FIXME
-        resp-p    (create-ledger consensus watcher ledger-id txn opts*)]
+        resp-p    (create-ledger consensus watcher ledger-id txn opts)]
     {:status 201, :body (deref! resp-p)}))

--- a/src/fluree/server/handlers/create.clj
+++ b/src/fluree/server/handlers/create.clj
@@ -3,7 +3,7 @@
    [fluree.db.api :as fluree]
    [fluree.db.util.log :as log]
    [fluree.server.consensus :as consensus]
-   [fluree.server.handlers.shared :refer [deref! defhandler]]
+   [fluree.server.handlers.shared :as shared :refer [deref! defhandler]]
    [fluree.server.handlers.transact :refer [derive-tx-id extract-ledger-id
                                             monitor-consensus-persistence
                                             monitor-commit]]
@@ -38,5 +38,8 @@
                                           ; upstream, and there are no policies
                                           ; in an empty ledger to allow any
                                           ; actions
-        resp-p    (create-ledger! consensus watcher ledger-id txn opts*)]
-    {:status 201, :body (deref! resp-p)}))
+        txn-resp  (deref! (create-ledger! consensus watcher ledger-id txn opts*))
+
+        body (select-keys txn-resp [:ledger :commit :t :tx-id])]
+    (shared/with-tracking-headers {:status 201, :body body}
+      txn-resp)))

--- a/src/fluree/server/handlers/ledger.clj
+++ b/src/fluree/server/handlers/ledger.clj
@@ -1,22 +1,26 @@
 (ns fluree.server.handlers.ledger
-  (:require
-   [fluree.db.api :as fluree]
-   [fluree.db.util.log :as log]
-   [fluree.server.handler :as-alias handler]
-   [fluree.server.handlers.shared :refer [defhandler deref!]]))
+  (:require [fluree.db.api :as fluree]
+            [fluree.db.util.log :as log]
+            [fluree.server.handler :as-alias handler]
+            [fluree.server.handlers.shared :refer [defhandler deref!] :as shared]))
 
 (defhandler query
   [{:keys [fluree/conn fluree/opts] {:keys [body]} :parameters :as _req}]
-  (let [query (or (::handler/query body) body)]
+  (let [query (or (::handler/query body) body)
+        {:keys [status result] :as query-response}
+        (deref! (fluree/query-connection conn query opts))]
     (log/debug "query handler received query:" query opts)
-    {:status 200
-     :body   (deref! (fluree/query-connection conn query opts))}))
+    (shared/with-tracking-headers {:status status, :body result}
+      query-response)))
 
 (defhandler history
   [{:keys [fluree/conn fluree/opts] {{ledger :from :as query} :body} :parameters :as _req}]
 
-  (let [ledger*       (->> ledger (fluree/load conn) deref!)
-        query*        (dissoc query :from)]
+  (let [ledger* (deref! (fluree/load conn ledger))
+        query*  (dissoc query :from)
+
+        {:keys [status result] :as history-response}
+        (deref! (fluree/history ledger* query* opts))]
     (log/debug "history handler received query:" query opts)
-    {:status 200
-     :body   (deref! (fluree/history ledger* query* opts))}))
+    (shared/with-tracking-headers {:status status, :body result}
+      history-response)))

--- a/src/fluree/server/handlers/shared.clj
+++ b/src/fluree/server/handlers/shared.clj
@@ -27,8 +27,28 @@
              (throw (ex-info "Error in ledger handler"
                              {:response
                               {:status status#
-                               :body   (assoc error# :message msg#)}})))))
+                               :body   (assoc error# :message msg#)}}
+                             e#)))))
        (catch Throwable t#
          (throw (ex-info "Error in ledger handler"
                          {:response {:status 500
-                                     :body   {:error (ex-message t#)}}}))))))
+                                     :body   {:error (ex-message t#)}}}
+                         t#))))))
+
+(defn with-header
+  [response header value]
+  (update response :headers assoc header value))
+
+(defn with-time-header
+  [response time]
+  (with-header response "x-fdb-time" time))
+
+(defn with-fuel-header
+  [response fuel]
+  (with-header response "x-fdb-fuel" (str fuel)))
+
+(defn with-tracking-headers
+  [response {:keys [time fuel policy]}]
+  (cond-> response
+    time (with-time-header time)
+    fuel (with-fuel-header fuel)))

--- a/src/fluree/server/handlers/shared.clj
+++ b/src/fluree/server/handlers/shared.clj
@@ -48,7 +48,7 @@
   (with-header response "x-fdb-fuel" (str fuel)))
 
 (defn with-tracking-headers
-  [response {:keys [time fuel policy]}]
+  [response {:keys [time fuel]}]
   (cond-> response
     time (with-time-header time)
     fuel (with-fuel-header fuel)))

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -77,13 +77,10 @@
           (deliver out-p ex))
 
         :else
-        (let [{:keys [ledger-id commit t tx-id]} result]
+        (let [{:keys [ledger-id commit t tx-id] :as commit-event} result]
           (log/debug "Transaction completed for:" ledger-id "tx-id:" tx-id "at t:" t
                      ". commit head:" commit)
-          (deliver out-p {:ledger ledger-id
-                          :commit commit
-                          :t      t
-                          :tx-id  tx-id}))))))
+          (deliver out-p commit-event))))))
 
 (defn transact!
   [consensus watcher ledger-id txn opts]

--- a/src/fluree/server/handlers/transact.clj
+++ b/src/fluree/server/handlers/transact.clj
@@ -52,7 +52,7 @@
         (let [ex (ex-info (str "Timeout waiting for transaction to complete for: "
                                ledger-id " with tx-id: " tx-id)
                           {:status 408
-                           :error  :db/response-timeout
+                           :error  :consensus/response-timeout
                            :ledger ledger-id
                            :tx-id  tx-id})]
           (deliver out-p ex))
@@ -63,7 +63,7 @@
                                ". Transaction may have processed, check ledger"
                                " for confirmation.")
                           {:status 500
-                           :error  :db/response-missing
+                           :error  :consensus/no-response
                            :ledger ledger-id
                            :tx-id  tx-id})]
           (deliver out-p ex))

--- a/test/fluree/server/integration/basic_query_test.clj
+++ b/test/fluree/server/integration/basic_query_test.clj
@@ -3,7 +3,7 @@
             [fluree.server.integration.test-system
              :as test-system
              :refer [api-post create-rand-ledger json-headers run-test-server]]
-            [jsonista.core :as json]))
+            [fluree.db.util.json :as json]))
 
 (use-fixtures :once run-test-server)
 
@@ -11,7 +11,7 @@
   (testing "can query a basic entity w/ JSON"
     (let [ledger-name (create-rand-ledger "query-endpoint-basic-entity-test")
           txn-req     {:body
-                       (json/write-value-as-string
+                       (json/stringify
                         {"ledger"   ledger-name
                          "@context" test-system/default-context
                          "insert"   [{"id"      "ex:query-test"
@@ -21,7 +21,7 @@
           txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))
           query-req   {:body
-                       (json/write-value-as-string
+                       (json/stringify
                         {"@context" test-system/default-context
                          "from"     ledger-name
                          "select"   '{?t ["*"]}
@@ -32,12 +32,12 @@
       (is (= [{"id"      "ex:query-test"
                "type"    "schema:Test"
                "ex:name" "query-test"}]
-             (-> query-res :body json/read-value)))))
+             (-> query-res :body (json/parse false))))))
 
   (testing "union query works"
     (let [ledger-name (create-rand-ledger "query-endpoint-union-test")
           txn-req     {:body
-                       (json/write-value-as-string
+                       (json/stringify
                         {"ledger"   ledger-name
                          "@context" test-system/default-context
                          "insert"   {"@graph"
@@ -51,7 +51,7 @@
           txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))
           query-req   {:body
-                       (json/write-value-as-string
+                       (json/stringify
                         {"@context" test-system/default-context
                          "from"     ledger-name
                          "select"   "?n"
@@ -62,12 +62,12 @@
           query-res   (api-post :query query-req)]
       (is (= 200 (:status query-res)))
       (is (= ["query-test" "Wes"]
-             (-> query-res :body json/read-value)))))
+             (-> query-res :body (json/parse false))))))
 
   (testing "optional query works"
     (let [ledger-name (create-rand-ledger "query-endpoint-optional-test")
           txn-req     {:body
-                       (json/write-value-as-string
+                       (json/stringify
                         {"ledger"   ledger-name
                          "@context" test-system/default-context
                          "insert"   {"@graph"
@@ -97,7 +97,7 @@
                                      "schema:name" ?name}
                                     ["optional" {"id" ?s, "ex:favColor" ?favColor}]]}
           query-req   {:body
-                       (json/write-value-as-string query)
+                       (json/stringify query)
                        :headers json-headers}
           query-res   (api-post :query query-req)]
       (is (= 200 (:status query-res))
@@ -105,13 +105,13 @@
       (is (= #{["Cam" nil]
                ["Alice" "Green"]
                ["Brian" nil]}
-             (-> query-res :body json/read-value set))
+             (-> query-res :body (json/parse false) set))
           (str "Response was: " (pr-str query-res)))))
 
   (testing "selectOne query works"
     (let [ledger-name (create-rand-ledger "query-endpoint-selectOne-test")
           txn-req     {:body
-                       (json/write-value-as-string
+                       (json/stringify
                         {"ledger"   ledger-name
                          "@context" test-system/default-context
                          "insert"   [{"id"      "ex:query-test"
@@ -121,7 +121,7 @@
           txn-res     (api-post :transact txn-req)
           _           (assert (= 200 (:status txn-res)))
           query-req   {:body
-                       (json/write-value-as-string
+                       (json/stringify
                         {"@context"  test-system/default-context
                          "from"      ledger-name
                          "selectOne" '{?t ["*"]}
@@ -132,7 +132,7 @@
       (is (= {"id"      "ex:query-test"
               "type"    "schema:Test"
               "ex:name" "query-test"}
-             (-> query-res :body json/read-value)))))
+             (-> query-res :body (json/parse false))))))
 
   (testing "bind query works"
     (let [ledger-name (create-rand-ledger "query-endpoint-bind-test")
@@ -149,7 +149,7 @@
                        "ex"     "http://example.org/"}
           txn-req     {:headers json-headers
                        :body
-                       (json/write-value-as-string
+                       (json/stringify
                         {"ledger"   ledger-name
                          "@context" context
                          "insert"
@@ -183,7 +183,7 @@
           txn-res   (api-post :transact txn-req)
           _         (assert (= 200 (:status txn-res)))
           query-req {:body
-                     (json/write-value-as-string
+                     (json/stringify
                       {"@context" context
                        "from"     ledger-name
                        "select"   ["?name" "?age" "?canVote"]
@@ -199,7 +199,7 @@
               ["Betty" 82 true]
               ["Freddy" 4 false]
               ["Leticia" 2 false]]
-             (-> query-res :body json/read-value))))))
+             (-> query-res :body (json/parse false)))))))
 
 #_(deftest ^:integration ^:edn query-edn-test
     (testing "can query a basic entity w/ EDN"

--- a/test/fluree/server/integration/basic_query_test.clj
+++ b/test/fluree/server/integration/basic_query_test.clj
@@ -1,9 +1,9 @@
 (ns fluree.server.integration.basic-query-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [fluree.db.util.json :as json]
             [fluree.server.integration.test-system
              :as test-system
-             :refer [api-post create-rand-ledger json-headers run-test-server]]
-            [fluree.db.util.json :as json]))
+             :refer [api-post create-rand-ledger json-headers run-test-server]]))
 
 (use-fixtures :once run-test-server)
 

--- a/test/fluree/server/integration/basic_transaction_test.clj
+++ b/test/fluree/server/integration/basic_transaction_test.clj
@@ -1,9 +1,9 @@
 (ns fluree.server.integration.basic-transaction-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [fluree.db.util.json :as json]
             [fluree.server.integration.test-system
              :refer [api-post create-rand-ledger json-headers run-test-server]
-             :as test-system]
-            [fluree.db.util.json :as json]))
+             :as test-system]))
 
 (use-fixtures :once run-test-server)
 
@@ -130,8 +130,8 @@
                                               "from"     ledger-name
                                               "where"    {"id" "?t", "type" "schema:Test"}})
                                    :headers json-headers})
-                  :body
-                  (json/parse false)))))))
+                 :body
+                 (json/parse false)))))))
 
 (deftest ^:integration ^:json transaction-with-ordered-list
   (testing ""

--- a/test/fluree/server/integration/basic_transaction_test.clj
+++ b/test/fluree/server/integration/basic_transaction_test.clj
@@ -3,14 +3,14 @@
             [fluree.server.integration.test-system
              :refer [api-post create-rand-ledger json-headers run-test-server]
              :as test-system]
-            [jsonista.core :as json]))
+            [fluree.db.util.json :as json]))
 
 (use-fixtures :once run-test-server)
 
 (deftest ^:integration ^:json create-endpoint-json-test
   (testing "can create a new ledger w/ JSON"
     (let [ledger-name (str "create-endpoint-" (random-uuid))
-          req         (json/write-value-as-string
+          req         (json/stringify
                        {"ledger"   ledger-name
                         "@context" {"foo" "http://foobar.com/"}
                         "insert"   [{"id"      "ex:create-test"
@@ -20,7 +20,7 @@
       (is (= 201 (:status res)))
       (is (= {"ledger" ledger-name
               "t"      1}
-             (-> res :body json/read-value (select-keys ["ledger" "t"])))))))
+             (-> res :body (json/parse false) (select-keys ["ledger" "t"])))))))
 
 #_(deftest ^:integration ^:edn create-endpoint-edn-test
     (testing "can create a new ledger w/ EDN"
@@ -53,7 +53,7 @@
 (deftest ^:integration ^:json transaction-json-test
   (testing "can transact in JSON"
     (let [ledger-name (create-rand-ledger "transact-endpoint-json-test")
-          req         (json/write-value-as-string
+          req         (json/stringify
                        {"@context" test-system/default-context
                         "ledger" ledger-name
                         "insert" {"id"      "ex:transaction-test"
@@ -62,12 +62,12 @@
           res         (api-post :transact {:body req :headers json-headers})]
       (is (= 200 (:status res)))
       (is (= {"ledger" ledger-name, "t" 2}
-             (-> res :body json/read-value (select-keys ["ledger" "t"])))))))
+             (-> res :body (json/parse false) (select-keys ["ledger" "t"])))))))
 
 (deftest ^:integration ^:json transaction-with-where-clause-test
   (testing "can transact with a where clause"
     (let [ledger-name (create-rand-ledger "transact-endpoint-json-test")
-          req1        (json/write-value-as-string
+          req1        (json/stringify
                        {"@context" test-system/default-context
                         "ledger"   ledger-name
                         "insert"   {"id"      "ex:transaction-test"
@@ -75,7 +75,7 @@
                                     "ex:name" "transact-endpoint-json-test"}})
           res1        (api-post :transact {:body req1, :headers json-headers})
           _           (assert (= 200 (:status res1)))
-          req2        (json/write-value-as-string
+          req2        (json/stringify
                        {"@context" test-system/default-context
                         "ledger"   ledger-name
                         "insert"   {"id"      "?t"
@@ -88,17 +88,17 @@
       (is (= [{"id"      "ex:transaction-test"
                "type"    "schema:Test"
                "ex:name" "new-name"}]
-             (->> {:body    (json/write-value-as-string
-                             {"@context" test-system/default-context
-                              "select"   {"ex:transaction-test" ["*"]}
-                              "from"     ledger-name})
-                   :headers json-headers}
-                  (api-post :query)
-                  :body
-                  json/read-value)))))
+             (-> (api-post :query {:body    (json/stringify
+                                             {"@context" test-system/default-context
+                                              "select"   {"ex:transaction-test" ["*"]}
+                                              "from"     ledger-name})
+                                   :headers json-headers})
+
+                 :body
+                 (json/parse false))))))
   (testing "can transact with a where clause w/ optional"
     (let [ledger-name (create-rand-ledger "transact-endpoint-json-test")
-          req1        (json/write-value-as-string
+          req1        (json/stringify
                        {"@context" test-system/default-context
                         "ledger"   ledger-name
                         "insert"   {"id"          "ex:transaction-test"
@@ -106,7 +106,7 @@
                                     "schema:name" "transact-endpoint-json-test"}})
           res1        (api-post :transact {:body req1, :headers json-headers})
           _           (assert (= 200 (:status res1)))
-          req2        (json/write-value-as-string
+          req2        (json/stringify
                        {"@context" test-system/default-context
                         "ledger"   ledger-name
                         "insert"   {"id"          "?t"
@@ -124,15 +124,14 @@
       (is (= [{"id"          "ex:transaction-test"
                "type"        "schema:Test"
                "schema:name" "new-name"}]
-             (->> {:body    (json/write-value-as-string
-                             {"@context" test-system/default-context
-                              "select"   {"?t" ["*"]}
-                              "from"     ledger-name
-                              "where"    {"id" "?t", "type" "schema:Test"}})
-                   :headers json-headers}
-                  (api-post :query)
+             (-> (api-post :query {:body    (json/stringify
+                                             {"@context" test-system/default-context
+                                              "select"   {"?t" ["*"]}
+                                              "from"     ledger-name
+                                              "where"    {"id" "?t", "type" "schema:Test"}})
+                                   :headers json-headers})
                   :body
-                  json/read-value))))))
+                  (json/parse false)))))))
 
 (deftest ^:integration ^:json transaction-with-ordered-list
   (testing ""
@@ -154,21 +153,21 @@
                             "ex:items1" "?items1"
                             "ex:items2" "?items2"}}]
       (is (= 200
-             (-> (api-post :transact {:body (json/write-value-as-string req1), :headers json-headers})
+             (-> (api-post :transact {:body (json/stringify req1), :headers json-headers})
                  :status)))
       (is (= [{"id" "ex:list-test",
                "ex:items1" ["zero" "one" "two" "three"]
                "ex:items2" ["four" "five" "six" "seven"]}]
-             (-> (api-post :query {:body (json/write-value-as-string q1) :headers json-headers})
+             (-> (api-post :query {:body (json/stringify q1) :headers json-headers})
                  :body
-                 json/read-value)))
+                 (json/parse false))))
       (is (= 200
-             (-> (api-post :transact {:body (json/write-value-as-string req2) :headers json-headers})
+             (-> (api-post :transact {:body (json/stringify req2) :headers json-headers})
                  :status)))
       (is (= [{"id" "ex:list-test"}]
-             (-> (api-post :query {:body (json/write-value-as-string q1) :headers json-headers})
+             (-> (api-post :query {:body (json/stringify q1) :headers json-headers})
                  :body
-                 json/read-value))))))
+                 (json/parse false)))))))
 
 #_(deftest ^:integration ^:edn transaction-edn-test
     (testing "can transact in EDN"

--- a/test/fluree/server/integration/closed_mode_test.clj
+++ b/test/fluree/server/integration/closed_mode_test.clj
@@ -1,9 +1,9 @@
 (ns fluree.server.integration.closed-mode-test
   (:require [clojure.test :as test :refer [deftest testing is]]
             [fluree.crypto :as crypto]
+            [fluree.db.util.json :as json]
             [fluree.server.integration.test-system
-             :refer [api-post auth json-headers jwt-headers run-closed-test-server]]
-            [fluree.db.util.json :as json]))
+             :refer [api-post auth json-headers jwt-headers run-closed-test-server]]))
 
 (test/use-fixtures :once run-closed-test-server)
 

--- a/test/fluree/server/integration/closed_mode_test.clj
+++ b/test/fluree/server/integration/closed_mode_test.clj
@@ -3,7 +3,7 @@
             [fluree.crypto :as crypto]
             [fluree.server.integration.test-system
              :refer [api-post auth json-headers jwt-headers run-closed-test-server]]
-            [jsonista.core :as json]))
+            [fluree.db.util.json :as json]))
 
 (test/use-fixtures :once run-closed-test-server)
 
@@ -43,7 +43,7 @@
                                     "f:action" [{"@id" "f:view"} {"@id" "f:modify"}]
                                     "f:query" {"@type" "@json"
                                                "@value" {}}}]}}
-            resp (api-post :create {:body    (crypto/create-jws (json/write-value-as-string create-req)
+            resp (api-post :create {:body    (crypto/create-jws (json/stringify create-req)
                                                                 (:private root-auth))
                                     :headers jwt-headers})]
         (testing "is accepted"
@@ -52,7 +52,7 @@
       (let [transact-req {"ledger" "closed-test"
                           "@context" default-context
                           "insert" [{"@id" "ex:coin" "ex:name" "nickel"}]}
-            resp (api-post :transact {:body (crypto/create-jws (json/write-value-as-string transact-req)
+            resp (api-post :transact {:body (crypto/create-jws (json/stringify transact-req)
                                                                (:private root-auth))
                                       :headers jwt-headers})]
         (testing "is accepted"
@@ -62,19 +62,19 @@
                        "@context" default-context
                        "where" [{"@id" "?s" "ex:name" "?name"}]
                        "select" "?s"}
-            resp (api-post :query {:body (crypto/create-jws (json/write-value-as-string query-req)
+            resp (api-post :query {:body (crypto/create-jws (json/stringify query-req)
                                                             (:private root-auth))
                                    :headers jwt-headers})]
         (testing "is accepted"
           (is (= 200 (:status resp)))
           (is (= ["did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh" "ex:coin"]
-                 (-> resp :body json/read-value))))))
+                 (-> resp :body (json/parse false)))))))
     (testing "to query history"
       (let [history-req {"from" "closed-test"
                          "@context" default-context
                          "history" "ex:coin"
                          "t" {"from" 1 "to" "latest"}}
-            resp (api-post :history {:body (crypto/create-jws (json/write-value-as-string history-req)
+            resp (api-post :history {:body (crypto/create-jws (json/stringify history-req)
                                                               (:private root-auth))
                                      :headers jwt-headers})]
         (testing "is accepted"
@@ -82,7 +82,7 @@
           (is (= [{"f:retract" [],
                    "f:assert" [{"ex:name" "nickel", "id" "ex:coin"}],
                    "f:t" 2}]
-                 (-> resp :body json/read-value)))))))
+                 (-> resp :body (json/parse false))))))))
 
   (testing "non-root request"
     (testing "to create"
@@ -98,17 +98,17 @@
                                     "f:action" [{"@id" "f:view"} {"@id" "f:modify"}]
                                     "f:query" {"@type" "@json"
                                                "@value" {}}}]}}
-            resp (api-post :create {:body    (crypto/create-jws (json/write-value-as-string create-req)
+            resp (api-post :create {:body    (crypto/create-jws (json/stringify create-req)
                                                                 (:private non-root-auth))
                                     :headers jwt-headers})]
         (testing "is rejected"
           (is (= 403 (:status resp)))
-          (is (= {"error" "Untrusted credential."} (-> resp :body json/read-value))))))
+          (is (= {"error" "Untrusted credential."} (-> resp :body (json/parse false)))))))
     (testing "to transact"
       (let [create-req {"ledger" "closed-test"
                         "@context" default-context
                         "insert" [{"@id" "ex:coin" "ex:name" "nickel"}]}
-            resp (api-post :transact {:body (crypto/create-jws (json/write-value-as-string create-req)
+            resp (api-post :transact {:body (crypto/create-jws (json/stringify create-req)
                                                                (:private non-root-auth))
                                       :headers jwt-headers})]
         (testing "is rejected"
@@ -118,23 +118,23 @@
                         "@context" default-context
                         "where" [{"@id" "?s" "ex:name" "?name"}]
                         "select" ["?s" "?name"]}
-            resp (api-post :query {:body (crypto/create-jws (json/write-value-as-string create-req)
+            resp (api-post :query {:body (crypto/create-jws (json/stringify create-req)
                                                             (:private non-root-auth))
                                    :headers jwt-headers})]
         (testing "is accepted"
           (is (= 200 (:status resp)))
-          (is (= [] (-> resp :body json/read-value))))))
+          (is (= [] (-> resp :body (json/parse false)))))))
     (testing "to query history"
       (let [create-req {"@context" default-context
                         "from" "closed-test"
                         "history" "ex:coin"
                         "t" {"from" 1}}
-            resp (api-post :history {:body (crypto/create-jws (json/write-value-as-string create-req)
+            resp (api-post :history {:body (crypto/create-jws (json/stringify create-req)
                                                               (:private non-root-auth))
                                      :headers jwt-headers})]
         (testing "is accepted"
           (is (= 200 (:status resp)))
-          (is (= [] (-> resp :body json/read-value))))))
+          (is (= [] (-> resp :body (json/parse false)))))))
     (testing "to claim more authority"
       (let [create-req {"from" "closed-test"
                         "@context" default-context
@@ -142,12 +142,12 @@
                         "select" ["?s" "?name"]
                         ;; claiming root-auth identity in opts
                         "opts" {"did" (:id root-auth)}}
-            resp (api-post :query {:body (crypto/create-jws (json/write-value-as-string create-req)
+            resp (api-post :query {:body (crypto/create-jws (json/stringify create-req)
                                                             (:private non-root-auth))
                                    :headers jwt-headers})]
         (testing "is silently demoted"
           (is (= 200 (:status resp)))
-          (is (= [] (-> resp :body json/read-value)))))))
+          (is (= [] (-> resp :body (json/parse false))))))))
 
   (testing "unsigned request"
     (testing "to create"
@@ -163,37 +163,37 @@
                                     "f:action" [{"@id" "f:view"} {"@id" "f:modify"}]
                                     "f:query" {"@type" "@json"
                                                "@value" {}}}]}}
-            resp (api-post :create {:body    (json/write-value-as-string create-req)
+            resp (api-post :create {:body    (json/stringify create-req)
                                     :headers json-headers})]
         (testing "is rejected"
           (is (= 400 (:status resp)))
-          (is (= {"error" "Missing credential."} (-> resp :body json/read-value))))))
+          (is (= {"error" "Missing credential."} (-> resp :body (json/parse false)))))))
     (testing "to transact"
       (let [transact-req {"ledger" "closed-test3"
                           "@context" default-context
                           "insert" [{"@id" "ex:coin" "ex:name" "nickel"}]}
-            resp (api-post :transact {:body (json/write-value-as-string transact-req)
+            resp (api-post :transact {:body (json/stringify transact-req)
                                       :headers json-headers})]
         (testing "is rejected"
           (is (= 400 (:status resp)))
-          (is (= {"error" "Missing credential."} (-> resp :body json/read-value))))))
+          (is (= {"error" "Missing credential."} (-> resp :body (json/parse false)))))))
     (testing "to query"
       (let [query-req {"from" "closed-test3"
                        "@context" default-context
                        "where" [{"@id" "?s" "ex:name" "?name"}]
                        "select" ["?s" "?name"]}
-            resp (api-post :query {:body (json/write-value-as-string query-req)
+            resp (api-post :query {:body (json/stringify query-req)
                                    :headers json-headers})]
         (testing "is accepted"
           (is (= 400 (:status resp)))
-          (is (= {"error" "Missing credential."} (-> resp :body json/read-value))))))
+          (is (= {"error" "Missing credential."} (-> resp :body (json/parse false)))))))
     (testing "to query history"
       (let [history-req {"from" "closed-test3"
                          "@context" default-context
                          "commit" true
                          "t" {"from" 1 "to" "latest"}}
-            resp (api-post :history {:body (json/write-value-as-string history-req)
+            resp (api-post :history {:body (json/stringify history-req)
                                      :headers json-headers})]
         (testing "is rejected"
           (is (= 400 (:status resp)))
-          (is (= {"error" "Missing credential."} (-> resp :body json/read-value))))))))
+          (is (= {"error" "Missing credential."} (-> resp :body (json/parse false)))))))))

--- a/test/fluree/server/integration/credential_test.clj
+++ b/test/fluree/server/integration/credential_test.clj
@@ -2,9 +2,9 @@
   (:require [clojure.core.async :refer [<!!]]
             [clojure.test :as test :refer [deftest testing is]]
             [fluree.db.json-ld.credential :as cred]
+            [fluree.db.util.json :as json]
             [fluree.server.integration.test-system
-             :refer [api-post auth json-headers run-test-server]]
-            [fluree.db.util.json :as json]))
+             :refer [api-post auth json-headers run-test-server]]))
 
 (test/use-fixtures :once run-test-server)
 

--- a/test/fluree/server/integration/credential_test.clj
+++ b/test/fluree/server/integration/credential_test.clj
@@ -4,7 +4,7 @@
             [fluree.db.json-ld.credential :as cred]
             [fluree.server.integration.test-system
              :refer [api-post auth json-headers run-test-server]]
-            [jsonista.core :as json]))
+            [fluree.db.util.json :as json]))
 
 (test/use-fixtures :once run-test-server)
 
@@ -38,12 +38,12 @@
                                       "f:query"  {"@type"  "@json"
                                                   "@value" {}}}]}}
             create-res (api-post :create
-                                 {:body    (json/write-value-as-string create-req)
+                                 {:body    (json/stringify create-req)
                                   :headers json-headers})]
         (is (= 201 (:status create-res)))
         (is (= {"ledger" "credential-test"
                 "t"      1}
-               (-> create-res :body json/read-value (select-keys ["ledger" "t"]))))))
+               (-> create-res :body (json/parse false) (select-keys ["ledger" "t"]))))))
     (testing "transact"
       (let [txn-req (<!! (cred/generate
                           {"ledger"   ledger-name
@@ -54,12 +54,12 @@
                                         "ex:foo"  1}]}
                           (:private auth)))
             txn-res (api-post :transact
-                              {:body    (json/write-value-as-string txn-req)
+                              {:body    (json/stringify txn-req)
                                :headers json-headers})]
         (is (= 200 (:status txn-res)))
         (is (= {"ledger" "credential-test"
                 "t"      2}
-               (-> txn-res :body json/read-value (select-keys ["ledger" "t"]))))))
+               (-> txn-res :body (json/parse false) (select-keys ["ledger" "t"]))))))
     (testing "query"
       (let [query-req (<!! (cred/generate
                             {"@context" default-context
@@ -69,14 +69,14 @@
                                          "type" "schema:Test"}}
                             (:private auth)))
             query-res (api-post :query
-                                {:body    (json/write-value-as-string query-req)
+                                {:body    (json/stringify query-req)
                                  :headers json-headers})]
         (is (= 200 (:status query-res)))
         (is (= [{"ex:name" "cred test",
                  "ex:foo"  1,
                  "id"      "ex:cred-test"
                  "type"    "schema:Test"}]
-               (-> query-res :body json/read-value)))))
+               (-> query-res :body (json/parse false))))))
 
     (testing "history"
       (let [history-req (<!! (cred/generate
@@ -87,7 +87,7 @@
                               (:private auth)))
 
             history-res (api-post :history
-                                  {:body    (json/write-value-as-string history-req)
+                                  {:body    (json/stringify history-req)
                                    :headers json-headers})]
         (is (= 200 (:status history-res)))
         (is (= [{"f:retract" [],
@@ -97,7 +97,7 @@
                    "id"      "ex:cred-test",
                    "type"    "schema:Test"}],
                  "f:t"       2}]
-               (-> history-res :body json/read-value)))))
+               (-> history-res :body (json/parse false))))))
 
     (testing "invalid credential"
       (let [valid-tx    (<!!
@@ -111,8 +111,8 @@
                                   "ALTEREDVALUE")
 
             invalid-res (api-post :transact
-                                  {:body    (json/write-value-as-string invalid-tx)
+                                  {:body    (json/stringify invalid-tx)
                                    :headers json-headers})]
         (is (= 400 (:status invalid-res)))
         (is (= {"error" "Invalid credential"}
-               (-> invalid-res :body json/read-value)))))))
+               (-> invalid-res :body (json/parse false))))))))

--- a/test/fluree/server/integration/history_query_test.clj
+++ b/test/fluree/server/integration/history_query_test.clj
@@ -3,7 +3,7 @@
             [fluree.server.integration.test-system
              :as test-system
              :refer [api-post json-headers run-test-server]]
-            [jsonista.core :as json]))
+            [fluree.db.util.json :as json]))
 
 (use-fixtures :once run-test-server)
 
@@ -20,7 +20,7 @@
   (testing "basic JSON history query works"
     (let [ledger-name   "history-query-json-test"
           txn-req       {:body
-                         (json/write-value-as-string
+                         (json/stringify
                           {"ledger"   ledger-name
                            "@context" test-system/default-context
                            "insert"   [{"id"      "ex:query-test"
@@ -30,7 +30,7 @@
           txn-res       (api-post :create txn-req)
           _             (assert (= 201 (:status txn-res)))
           txn2-req      {:body
-                         (json/write-value-as-string
+                         (json/stringify
                           {"ledger"   ledger-name
                            "@context" test-system/default-context
                            "insert"   [{"id"           "ex:query-test"
@@ -39,14 +39,14 @@
           txn2-res      (api-post :transact txn2-req)
           _             (assert (= 200 (:status txn2-res)))
           query-req     {:body
-                         (json/write-value-as-string
+                         (json/stringify
                           {"@context"       test-system/default-context
                            "from"           ledger-name
                            "commit-details" true
                            "t"              {"at" "latest"}})
                          :headers json-headers}
           query-res     (api-post :history query-req)
-          query-results (-> query-res :body json/read-value)]
+          query-results (-> query-res :body (json/parse false))]
       (is (= 200 (:status query-res))
           (str "History query response was: " (pr-str query-res)))
       (let [history-expectations

--- a/test/fluree/server/integration/history_query_test.clj
+++ b/test/fluree/server/integration/history_query_test.clj
@@ -1,9 +1,9 @@
 (ns fluree.server.integration.history-query-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [fluree.db.util.json :as json]
             [fluree.server.integration.test-system
              :as test-system
-             :refer [api-post json-headers run-test-server]]
-            [fluree.db.util.json :as json]))
+             :refer [api-post json-headers run-test-server]]))
 
 (use-fixtures :once run-test-server)
 

--- a/test/fluree/server/integration/load_state_test.clj
+++ b/test/fluree/server/integration/load_state_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [fluree.server.integration.test-system :refer [api-post json-headers] :as test-system]
             [fluree.server.system :as system]
-            [jsonista.core :as json]
+            [fluree.db.util.json :as json]
             [test-with-files.tools :refer [with-tmp-dir] :as twf]))
 
 (deftest ^:integration shacl-test
@@ -26,16 +26,16 @@
                                    "ex:email" {"@id" "foobar@flur.ee", "@type" "ex:Email"}}]}]
       (testing "validation works on initial server run"
         (is (= 201
-               (-> (api-post :create {:body (json/write-value-as-string create-req) :headers json-headers})
+               (-> (api-post :create {:body (json/stringify create-req) :headers json-headers})
                    :status)))
         (is (= 422
-               (-> (api-post :transact {:body (json/write-value-as-string txn-req) :headers json-headers})
+               (-> (api-post :transact {:body (json/stringify txn-req) :headers json-headers})
                    :status))))
       (testing "validation works on server restart"
         (system/stop server)
         (let [new-server (system/start-config (test-system/file-server-config storage-path))]
           (is (= 422
-                 (-> (api-post :transact {:body (json/write-value-as-string txn-req) :headers json-headers})
+                 (-> (api-post :transact {:body (json/stringify txn-req) :headers json-headers})
                      :status)))
           (system/stop new-server))))))
 
@@ -60,16 +60,16 @@
                  "select" {"?s" ["*"]}}]
       (testing "validation works on initial server run"
         (is (= 201
-               (-> (api-post :create {:body (json/write-value-as-string create) :headers json-headers})
+               (-> (api-post :create {:body (json/stringify create) :headers json-headers})
                    :status)))
         (is (= [{"@id"      "freddy",
                  "age"      4,
                  "name"     "Freddy",
                  "verified" true,
                  "@type"    "Yeti"}]
-               (-> (api-post :query {:body (json/write-value-as-string query) :headers json-headers})
+               (-> (api-post :query {:body (json/stringify query) :headers json-headers})
                    :body
-                   json/read-value))))
+                   (json/parse false)))))
       (testing "validation works on server restart"
         (system/stop server)
         (let [new-server (system/start-config (test-system/file-server-config storage-path))]
@@ -78,7 +78,7 @@
                    "name"     "Freddy",
                    "verified" true,
                    "@type"    "Yeti"}]
-                 (-> (api-post :query {:body (json/write-value-as-string query) :headers json-headers})
+                 (-> (api-post :query {:body (json/stringify query) :headers json-headers})
                      :body
-                     json/read-value)))
+                     (json/parse false))))
           (system/stop new-server))))))

--- a/test/fluree/server/integration/load_state_test.clj
+++ b/test/fluree/server/integration/load_state_test.clj
@@ -1,8 +1,8 @@
 (ns fluree.server.integration.load-state-test
   (:require [clojure.test :refer [deftest is testing]]
+            [fluree.db.util.json :as json]
             [fluree.server.integration.test-system :refer [api-post json-headers] :as test-system]
             [fluree.server.system :as system]
-            [fluree.db.util.json :as json]
             [test-with-files.tools :refer [with-tmp-dir] :as twf]))
 
 (deftest ^:integration shacl-test

--- a/test/fluree/server/integration/policy_test.clj
+++ b/test/fluree/server/integration/policy_test.clj
@@ -3,10 +3,10 @@
             [clojure.test :refer [deftest is testing use-fixtures]]
             [fluree.crypto :as crypto]
             [fluree.db.json-ld.credential :as cred]
+            [fluree.db.util.json :as json]
             [fluree.server.integration.test-system
              :as test-system
-             :refer [api-post auth create-rand-ledger json-headers sparql-headers run-test-server]]
-            [fluree.db.util.json :as json]))
+             :refer [api-post auth create-rand-ledger json-headers sparql-headers run-test-server]]))
 
 (use-fixtures :once run-test-server)
 

--- a/test/fluree/server/integration/remote_system_test.clj
+++ b/test/fluree/server/integration/remote_system_test.clj
@@ -1,9 +1,9 @@
 (ns fluree.server.integration.remote-system-test
   (:require [clojure.test :refer [are deftest testing use-fixtures]]
+            [fluree.db.util.json :as json]
             [fluree.server.integration.test-system :as test-system
              :refer [api-post create-rand-ledger json-headers]]
-            [fluree.server.system :as system]
-            [fluree.db.util.json :as json]))
+            [fluree.server.system :as system]))
 
 (def all-ports (test-system/find-open-ports 3))
 (def authors-port (nth all-ports 0))

--- a/test/fluree/server/integration/remote_system_test.clj
+++ b/test/fluree/server/integration/remote_system_test.clj
@@ -3,7 +3,7 @@
             [fluree.server.integration.test-system :as test-system
              :refer [api-post create-rand-ledger json-headers]]
             [fluree.server.system :as system]
-            [jsonista.core :as json]))
+            [fluree.db.util.json :as json]))
 
 (def all-ports (test-system/find-open-ports 3))
 (def authors-port (nth all-ports 0))
@@ -165,7 +165,7 @@
                      "xsd"    "http://www.w3.org/2001/XMLSchema#"}
 
             authors-ledger      (create-rand-ledger "test/authors" authors-port)
-            authors-insert-req  {:body    (json/write-value-as-string
+            authors-insert-req  {:body    (json/stringify
                                            {"@context" [context "https://schema.org"]
                                             "ledger"   authors-ledger
                                             "insert"   [{"@id"   "https://www.wikidata.org/wiki/Q42"
@@ -178,7 +178,7 @@
             authors-insert-resp (api-post :transact authors-insert-req authors-port)
 
             books-ledger      (create-rand-ledger "test/books" books-port)
-            books-insert-req  {:body    (json/write-value-as-string
+            books-insert-req  {:body    (json/stringify
                                          {"@context" [context "https://schema.org"]
                                           "ledger"   books-ledger
                                           "insert"   [{"id"     "https://www.wikidata.org/wiki/Q3107329",
@@ -195,7 +195,7 @@
             books-insert-resp (api-post :transact books-insert-req books-port)
 
             movies-ledger      (create-rand-ledger "test/movies" movies-port)
-            movies-insert-req  {:body    (json/write-value-as-string
+            movies-insert-req  {:body    (json/stringify
                                           {"@context" [context "https://schema.org"]
                                            "ledger"   movies-ledger
                                            "insert"   [{"id"                        "https://www.wikidata.org/wiki/Q836821",
@@ -233,7 +233,7 @@
           authors-insert-resp books-insert-resp movies-insert-resp)
 
         (testing "can be queried for their combined data set no matter which system the query originates"
-          (let [query-req         {:body    (json/write-value-as-string
+          (let [query-req         {:body    (json/stringify
                                              {"@context" "https://schema.org"
                                               "from"     [authors-ledger books-ledger movies-ledger]
                                               "select"   ["?movieName" "?bookIsbn" "?authorName"]
@@ -254,5 +254,5 @@
               author-query-resp book-query-resp movie-query-resp)
 
             ;; Each system returned the same and correct answer when queired
-            (are [resp] (-> resp :body json/read-value (= correct-answer))
+            (are [resp] (-> resp :body (json/parse false) (= correct-answer))
               author-query-resp book-query-resp movie-query-resp)))))))

--- a/test/fluree/server/integration/sparql_test.clj
+++ b/test/fluree/server/integration/sparql_test.clj
@@ -1,10 +1,10 @@
 (ns fluree.server.integration.sparql-test
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
+            [fluree.db.util.json :as json]
             [fluree.server.integration.test-system
              :refer [api-post create-rand-ledger run-test-server sparql-headers
-                     sparql-results-headers sparql-update-headers]]
-            [fluree.db.util.json :as json]))
+                     sparql-results-headers sparql-update-headers]]))
 
 (use-fixtures :once run-test-server)
 

--- a/test/fluree/server/integration/sparql_test.clj
+++ b/test/fluree/server/integration/sparql_test.clj
@@ -4,7 +4,7 @@
             [fluree.server.integration.test-system
              :refer [api-post create-rand-ledger run-test-server sparql-headers
                      sparql-results-headers sparql-update-headers]]
-            [jsonista.core :as json]))
+            [fluree.db.util.json :as json]))
 
 (use-fixtures :once run-test-server)
 
@@ -49,7 +49,7 @@
               "results"
               {"bindings"
                [{"name" {"value" "query-sparql-test", "type" "literal"}}]}}
-             (-> query-res :body json/read-value)))
+             (-> query-res :body (json/parse false))))
 
       (is (= 200 (:status meta-res)))
       (is (= {"status" 200,
@@ -58,10 +58,10 @@
                {"bindings"
                 [{"name" {"value" "query-sparql-test", "type" "literal"}}]},
                "head" {"vars" ["name"]}}}
-             (-> meta-res :body json/read-value (dissoc "time"))))
+             (-> meta-res :body (json/parse false) (dissoc "time"))))
       (is (= 2 (-> meta-res :headers (get "x-fdb-fuel") Integer/parseInt)))
       (is (= 200 (:status rdf-res)))
       (is (= {"@context" {"ex" "http://example.org/" "schema" "http://schema.org/"},
               "@graph" [{"@id" "ex:query-sparql-test"
                          "foo:name" ["query-sparql-test"]}]}
-             (-> rdf-res :body json/read-value))))))
+             (-> rdf-res :body (json/parse false)))))))

--- a/test/fluree/server/integration/sparql_test.clj
+++ b/test/fluree/server/integration/sparql_test.clj
@@ -52,13 +52,11 @@
              (-> query-res :body (json/parse false))))
 
       (is (= 200 (:status meta-res)))
-      (is (= {"status" 200,
-              "result"
-              {"results"
-               {"bindings"
-                [{"name" {"value" "query-sparql-test", "type" "literal"}}]},
-               "head" {"vars" ["name"]}}}
-             (-> meta-res :body (json/parse false) (dissoc "time"))))
+      (is (= {"results"
+              {"bindings"
+               [{"name" {"value" "query-sparql-test", "type" "literal"}}]},
+              "head" {"vars" ["name"]}}
+             (-> meta-res :body (json/parse false))))
       (is (= 2 (-> meta-res :headers (get "x-fdb-fuel") Integer/parseInt)))
       (is (= 200 (:status rdf-res)))
       (is (= {"@context" {"ex" "http://example.org/" "schema" "http://schema.org/"},


### PR DESCRIPTION
This patch removes the middleware to set response headers in favor of a function that each handler can call because each response between history, transaction, and queries have different shapes which shouldn't be handled by a general middleware. It also adds fuel, policy, and response time values to the transaction completed events so that these values can be returned in the headers, and encodes the policy header as a base64 encoded json string.