### PR TITLE
Add config into to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,99 +1,210 @@
 # Fluree Server
-Creating and updating ledgers must be done by a service that not only has the rights to update them, but is also
-responsible for the current ledger state and persisting updates to storage.
 
-While this can be done using just Fluree's db library (using, for example, IPFS for persistent storage), for
-an environment that will have many clients, like an app with many users, it is typical to want dedicated server(s)
-to handle consistent transaction ordering, communicating out ledger updates, redundancy, and other
-"server" features that would be expected for a reliable, scalable, and fault-tolerant environment.
+Fluree Server wraps the [fluree/db](https://github.com/fluree/db) library with
+an HTTP API server and consensus capabilities. While fluree/db can be used
+directly in applications for embedded database functionality, Fluree Server
+provides the infrastructure needed for multi-client environments requiring
+consistent transaction ordering, ledger state management, and distributed
+consensus.
 
-Fluree Server provides these features. It can be run stand-alone, in conjunction with Fluree's db library, or as a cluster
-of servers providing scale and/or distributed consensus, or all of the above. You can start with a single server while
-in development, then add more servers once ready to scale.
+The server can run as either a consensus-participating node for transaction
+processing or as a query-only node for horizontal scaling. Multiple servers can
+form a cluster for fault tolerance and performance.
 
-Fluree Server can be run as either a consensus-participating node processing transactions/updates, or as query-only server that scales out
-query processing horizontally, and to the edge if desired. Fluree Server can have any number of consensus-participating
-nodes that together reliably maintain ledger updates for any number of ledgers.
+**Key Features:**
+- **High Availability**: Automatic failover and work redistribution when
+  servers join or leave
+- **Guaranteed Ordering**: Consistent transaction processing across all nodes
+- **Horizontal Scaling**: Add query-only nodes for read performance
+- **Load Distribution**: Automatic workload balancing across consensus nodes
+- **Duplicate Prevention**: Built-in transaction deduplication
 
-Note that Fluree's db library, which can be included directly into your application, can also process queries which
-not only provides further scale, but can wrap a distributed database with your custom functionality at in-memory speeds.
-Your app can benefit from timely, fast, and simple information lookups/queries, eliminating the need to make remote db calls.
+## Quick Start
 
-### Designing a Fluree Server network
-Fluree Server runs as either a consensus participating node + query server, or as a query-only server depending on
-the startup configuration. While a single server can be run as both a consensus participating node and a query server,
-it lacks fault-tolerance and redundancy (if using local storage, vs cloud/IPFS storage).
+The quickest way to run Fluree Server with Docker:
 
-Three connected Fluree Servers running consensus is the recommended minimum for a production environment, which will
-provide fault-tolerance and redundancy allowing any single server to fail with zero downtime. Three servers also
-provide scale, as any of them can serve query results and transaction processing will be split amongst them
-for different ledgers being maintained.
+```bash
+docker run -p 58090:8090 -v `pwd`/data:/opt/fluree-server/data fluree/server
+```
 
-For additional query scale, you'd typically start adding one or more query-only servers that connect to the consensus
-servers. Query servers are ephemeral, are great for containerization and
-auto-scaling. They can also be deployed at the edge for performance. Query-only servers accumulate ledger index data
-in-memory (up to your configured max memory) and garbage collect the least recently used data once the memory allocated
-is full. The in-memory index data allows for fast query processing at the edge.
+For comprehensive documentation, visit
+[https://developers.flur.ee](https://developers.flur.ee).
 
-When using query-only servers, you'd typically have your clients/apps connect to them instead of directly to the consensus
-servers. Transactions received by the query-only servers are forwarded to the consensus servers for processing, and
-they utilize a CQRS pattern to communicate ledger updates back to the connected clients. For private ledgers, it
-would be typical to put the consensus servers in a private network, and have the query-only servers in a public network
-such that no clients could connect directly to the consensus servers.
-
-For added redundancy, scale, fault-tolerance, or to accommodate a number of decentralized participants in a network you
-can run more than 3 consensus servers. The failure formula `2f+1=n` applies, where `f` is the number of servers that can fail
-with the network still being able to reach consensus, and `n` is the total number of servers in the network.
-So, for example, if you wanted to allow for 2 failures while still maintaining consensus and uptime, you'd need 5 servers
-(`2*2+1=5`). If you wanted to allow for 3 server failures, you'd need 7 servers (`2*3+1=7`). As you'll note, the number of
-servers is always an odd number as >50% of the network must be "alive", and therefore while an even number of servers is allowed, it is not recommended.
+The sections below cover custom configurations and building from source.
 
 ## Usage
 
 ### Settings
-Configuration is handled through environment variables, with defaults provided via `resources/config.edn` file.  See the [Fluree docs](https://docs.flur.ee/docs/running-fluree/configuration) for more information.
+Configuration is handled through JSON-LD configuration files with samples (and
+the default) located in the `resources/` directory. The server can be started
+with different configuration files and profiles. 
 
-The most common environment variables to set would include:
-- `FLUREE_HTTP_API_PORT` - the TCP port to serve the HTTP API on (default: 8090). Used primarily to server query requests.
-- `FLUREE_CACHE_MAX_MB` - the maximum amount of memory to use for in-memory database index data in megabytes (default: 1000, or 1GB).
-- `FLUREE_SERVERS` - Server(s) for a query server to connect to for retrieving state and receiving updates. If set, this server will run as an ephemeral query-only server, which enables horizontal (edge) scalability of query processing
-  (it is not a consensus participating node). Provide a comma-separated list of servers in the
-  [multi-address format](https://github.com/libp2p/specs/blob/master/addressing/README.md) which this server can connect to for state and update events.
-  This would typically be the same servers as `FLUREE_CONSENSUS_SERVERS`, but with their respective configured external `FLUREE_HTTP_API_PORT`.
-- `FLUREE_CONSENSUS_SERVERS` - Only needed for consensus servers (disregard for query-only servers). A comma-separated list of server(s) processing transactions and participating in consensus using the
-  [multi-address format](https://github.com/libp2p/specs/blob/master/addressing/README.md). The TCP port specified in this list
-  is *only* used for consensus-server communication and must be open between the respective listed servers, but can be closed to all other traffic.
-  Example of a 3-server cluster specifying IP addresses: `FLUREE_SERVERS=/ip4/10.0.0.1/tcp/62071,/ip4/10.0.0.2/tcp/62071,/ip4/10.0.0.3/tcp/62071`.
-- `FLUREE_CONSENSUS_THIS_SERVER` - Only needed for consensus servers (disregard for query-only servers).
-  This identifies which of the above `FLUREE_CONSENSUS_SERVERS` is the current server. Using the 3 server cluster example above, each
-  of the three servers will have a different value for FLUREE_THIS_SERVER, e.g. the first server would have `FLUREE_THIS_SERVER=/ip4/10.0.0.1/tcp/62071`
+**Note:** The Fluree server does not currently support environment variables for
+configuration overrides. All configuration must be provided through JSON-LD
+files or command-line arguments.
 
+#### Configuration Files
+Sample configuration files are provided in the `resources/` directory:
+- `file-config.jsonld` - Default standalone server configuration with
+  file-based storage
+- `memory-config.jsonld` - Standalone server configuration with in-memory
+  storage
+- `config-raft.jsonld` - Raft consensus cluster configuration
+- `config-raft-standalone.jsonld` - Single-node Raft configuration for
+  development
 
-## Features
-- Can run as either (a) a node participating in consensus + query server, or (b) an ephemeral in-memory query-only server (scale-out server) based on if `FLUREE_SERVERS` environment variable is configured.
-- Maintains queue of transactions with guaranteed ordering across all servers
-- Maintains consistent state for all ledgers managed in the cluster across all participating servers
-- Distributes transaction processing across all servers in the cluster (on a per-ledger basis)
-- Caching to quickly verify duplicate transactions are not processed twice
-- If a server fails, it is auto-detected and the work of the server is redistributed to the remaining servers in the cluster
-- If a server joins, work is redistributed to include the new server
+#### Starting the Server
+The server can be started in different ways:
+- Default: Uses `file-config.jsonld` from resources
+- With specific config file: `--config /path/to/config.jsonld`
+- With specific resource: `--resource config-name.jsonld`
+- With config string: `--string "{config json}"`
+- With profile: `--profile dev` (applies profile-specific overrides)
+
+#### Configuration Options
+The configuration files use the Fluree system vocabulary. Common configuration
+settings include:
+
+**Storage Configuration:**
+- `filePath` - Directory path for file-based storage (e.g.,
+  "/opt/fluree-server/data" or "dev/data")
+- `@type: "Storage"` - Defines storage configuration (omit filePath for memory
+  storage)
+
+**Connection Configuration:**
+- `parallelism` - Number of parallel operations (default: 4)
+- `cacheMaxMb` - Maximum memory for caching in MB (default: 1000)
+- `commitStorage` - Reference to storage configuration for commits
+- `indexStorage` - Reference to storage configuration for indexes
+- `primaryPublisher` - Primary publisher configuration
+- `secondaryPublishers` - Optional array of secondary publishers
+- `defaults.indexing.reindexMinBytes` - Minimum bytes before reindexing
+  (default: 1000000)
+- `defaults.indexing.reindexMaxBytes` - Maximum bytes before reindexing
+  (default: 1000000000)
+
+**Consensus Configuration:**
+- `consensusProtocol` - Either "standalone" or "raft"
+- `maxPendingTxns` - Maximum pending transactions (standalone mode,
+  default: 512)
+
+**Raft-specific Configuration:**
+- `raftLogHistory` - Number of log entries to keep (default: 10)
+- `raftEntriesMax` - Maximum entries per batch (default: 200)
+- `raftCatchUpRounds` - Catch-up rounds for lagging nodes (default: 10)
+- `raftServers` - Array of server addresses in multi-address format (e.g.,
+  "/ip4/127.0.0.1/tcp/62071")
+- `raftThisServer` - This server's address from the raftServers list
+
+**HTTP API Configuration:**
+- `httpPort` - Port for HTTP API (default: 8090)
+- `maxTxnWaitMs` - Maximum transaction wait time in milliseconds
+  (default: 120000)
+- `closedMode` - Enable closed mode (requires authentication)
+- `rootIdentities` - Array of root identity DIDs for authentication
+
+#### Example Configuration
+Here's a minimal standalone server configuration:
+```json
+{
+  "@context": {
+    "@base": "https://ns.flur.ee/config/main/",
+    "@vocab": "https://ns.flur.ee/system#"
+  },
+  "@id": "myServer",
+  "@graph": [
+    {
+      "@id": "storage",
+      "@type": "Storage",
+      "filePath": "/data/fluree"
+    },
+    {
+      "@id": "connection",
+      "@type": "Connection",
+      "cacheMaxMb": 500,
+      "commitStorage": {"@id": "storage"},
+      "indexStorage": {"@id": "storage"}
+    },
+    {
+      "@id": "consensus",
+      "@type": "Consensus",
+      "consensusProtocol": "standalone",
+      "connection": {"@id": "connection"}
+    },
+    {
+      "@id": "http",
+      "@type": "API",
+      "httpPort": 8090
+    }
+  ]
+}
+```
+
+#### Profiles
+Configuration files can include profiles that override base settings. For
+example, a "dev" profile might use less memory and local file paths:
+```json
+"profiles": {
+  "dev": [
+    {
+      "@id": "storage",
+      "filePath": "dev/data"
+    },
+    {
+      "@id": "connection",
+      "cacheMaxMb": 200
+    }
+  ]
+}
+```
+
+### Network Architecture
+
+**Server Types:**
+- **Consensus nodes**: Process transactions and maintain ledger state. Minimum 3
+  for production (allows 1 failure).
+- **Query-only nodes**: Ephemeral servers for horizontal query scaling. Great
+  for containers and edge deployment.
+
+**Deployment Patterns:**
+- **Small**: 3 consensus nodes (handles 1 failure)
+- **Medium**: 3-5 consensus nodes + multiple query nodes
+- **Large**: 5+ consensus nodes (formula: `2f+1=n` where `f` = allowed
+  failures)
+
+**Best Practices:**
+- Route client traffic through query-only nodes
+- Keep consensus nodes in private networks
+- Query nodes forward transactions to consensus nodes using CQRS pattern
+- Query nodes cache data in-memory with LRU eviction
 
 ## Development
 
 ### Dependencies
 
-Run `make prepare` to compile the required dependencies to enable Clojure development.
+Run `make help` to see all available tasks.
+
+### Building
+
+- `make` or `make uberjar` - Build an executable server uberjar
+- `make docker-build` - Build the server Docker container
+- `make docker-push` - Build and publish the server Docker container
+
+### Testing
+
+- `make test` - Run tests
+- `make benchmark` - Run performance benchmarks
+- `make pending-tests` or `make pt` - Run pending tests
 
 ### Code linting
 
-- Code linters can be run via `bb run lint`
-    - This will run cljfmt and clj-kondo on the entire codebase
-- cljfmt can automatically fix the formatting errors it finds
-    - You can run this on the whole codebase by invoking `bb run fix`
-    - clj-kondo cannot automatically fix the issues it finds
+- `bb lint` - Run both cljfmt and clj-kondo on the entire codebase
+- `bb fix` - Automatically fix formatting errors with cljfmt
+- `make clj-kondo-lint` - Run clj-kondo separately
+- `make cljfmt-check` - Check formatting with cljfmt
+- `make cljfmt-fix` - Fix formatting errors with cljfmt
 
 ### Git hooks
 
-- Run `bb run git-hooks install`
-    - This will set up a pre-commit git hook that checks your staged changes
-      with cljfmt and clj-kondo before allowing them to be committed.
+- `bb git-hooks install` - Set up a pre-commit git hook that checks your staged
+  changes with cljfmt and clj-kondo before allowing them to be committed


### PR DESCRIPTION
Updates README. The current version was incorrect and old. When the changes for the JSON-LD configuration were introduced, it wasn't updated and nobody would be able to use it as it stood.

Update the startup requirements along with updating docs a little bit.