### PR TITLE
add `make run` and similar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,3 +60,15 @@ cljfmt-fix:
 clean: ## Remove build artifacts
 	rm -rf target
 	rm -rf .cpcache
+
+.PHONY: run
+run: ## Run the server without building JAR (development mode)
+	clojure -M:run-dev
+
+.PHONY: run-prod
+run-prod: ## Run the server without building JAR (production mode)
+	clojure -M -m fluree.server
+
+.PHONY: build-and-run
+build-and-run: uberjar ## Build JAR and run the server
+	java -jar target/server-*.jar

--- a/README.md
+++ b/README.md
@@ -27,11 +27,17 @@ The quickest way to run Fluree Server with Docker:
 docker run -p 58090:8090 -v `pwd`/data:/opt/fluree-server/data fluree/server
 ```
 
-Or run directly with Java (requires Java 11+):
+Or run from source (requires Java 11+ and Clojure):
 
 ```bash
-# Download the latest JAR from releases or build from source (instructions below)
-java -jar fluree-server.jar --config /path/to/config.jsonld
+# Run directly without building JAR (development mode)
+make run
+
+# Build and run in one command
+make build-and-run
+
+# Run with custom config
+java -jar target/server-*.jar --config /path/to/config.jsonld
 ```
 
 For comprehensive documentation, visit


### PR DESCRIPTION
This adds a new `make run` command which starts up fluree/server from CLJ using the dev profile.

Also added `make run-prod` which starts up in the default production profile.

Also `make build-and-run` which will compile the .jar then run the .jar

Updated README to reflect new options.