### PR TITLE
update db version and add explicit crypto dep

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,11 +1,12 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "ee519035cca1ee9e7e9f75b0827d5406c7155006"}
+                                :git/sha "d674111dc0f2f1e2d061e558001e852a28ed5eaf"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
 
         integrant/integrant {:mvn/version "0.10.0"}
+        com.fluree/crypto   {:mvn/version "3.0.1"}
 
         ;; network, consensus
         com.github.fluree/raft {:git/tag "v1.0.0-beta2"


### PR DESCRIPTION
We use the crypto lib in server via its inclusion in db, and we should depend directly on it if we are using it.