### PR TITLE
Update fluree/db dependency to latest version

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "33f8a5889a424df9644eaeae6dcaec313c26a199"}
+                                :git/sha "77566ad607f2bb268caa99bd8821599a8b40d848"}
 
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}


### PR DESCRIPTION
## Summary
Update fluree/db dependency from `33f8a5889a424df9644eaeae6dcaec313c26a199` to `77566ad607f2bb268caa99bd8821599a8b40d848`

## Changes
- Update git SHA in deps.edn for com.fluree/db dependency

## Testing
- All tests pass: 20 tests, 232 assertions, 0 failures
- No breaking changes detected with the new dependency version

The dependency update is working correctly and maintains compatibility with existing functionality.