### PR TITLE
update json-ld dep

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,8 +2,7 @@
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
                                 :git/sha "bf1926a384b47f736c4151491f60425506564600"}
-        com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
-                                :git/sha "73a990a4b803d0b4cfbbbe4dc16275b39a3add4e"}
+        com.fluree/json-ld     {:mvn/version "1.0.1"}
 
         integrant/integrant {:mvn/version "0.10.0"}
         com.fluree/crypto   {:mvn/version "3.0.1"}

--- a/test/fluree/server/integration/credential_test.clj
+++ b/test/fluree/server/integration/credential_test.clj
@@ -102,7 +102,7 @@
     (testing "invalid credential"
       (let [valid-tx    (<!!
                          (cred/generate {"ledger"   ledger-name
-                                         "@context" ["https://ns.flur.ee", {"ex" "http://example.com/ns/"}]
+                                         "@context" ["https://ns.flur.ee/ledger/v1", {"ex" "http://example.com/ns/"}]
                                          "insert"   {"@id"    "ex:cred-test"
                                                      "ex:KEY" "VALUE"}}
                                         (:private auth)))


### PR DESCRIPTION
The git dep on json-ld conflicts with the mvn dep on json-ld in the db library, this ensures that when server is used as a library there is no transitive dependency conflict (git deps and maven deps are not comparable by clojure, so the build fails).