### PR TITLE
Enable ledger creation without initial transaction data

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,18 +50,43 @@ The sections below cover custom configurations and building from source.
 Here are examples using curl to demonstrate key Fluree Server features. These
 examples assume the server is running on the default port 8090.
 
-### Create a New Ledger with an Initial Commit
+### Create a New Ledger
 
 ```bash
 curl -X POST http://localhost:8090/fluree/create \
   -H "Content-Type: application/json" \
   -d '{
-    "ledger": "example/ledger",
+    "ledger": "example/ledger"
+  }'
+```
+
+Expected output:
+```json
+{
+  "ledger": "example/ledger",
+  "t": 0,
+  "tx-id": "089aeb0dd3a5cbef5cafd76aee57b71ff039ec35c9ce574daafa891c6c401381",
+  "commit": {
+    "address": "fluree:memory://...",
+    "hash": "..."
+  }
+}
+```
+
+### Insert Data
+
+After creating the ledger, you can add data using the `/insert` endpoint:
+
+```bash
+curl -X POST http://localhost:8090/fluree/insert \
+  -H "Content-Type: application/json" \
+  -H "fluree-ledger: example/ledger" \
+  -d '{
     "@context": {
       "schema": "http://schema.org/",
       "ex": "http://example.org/"
     },
-    "insert": [{
+    "@graph": [{
       "@id": "ex:alice",
       "@type": "schema:Person",
       "schema:name": "Alice Johnson",
@@ -75,7 +100,7 @@ Expected output:
 {
   "ledger": "example/ledger",
   "t": 1,
-  "tx-id": "089aeb0dd3a5cbef5cafd76aee57b71ff039ec35c9ce574daafa891c6c401381",
+  "tx-id": "f4de14124f6121125b20dace04f6867326639b786d65eb542a3d02e1d6c1787e",
   "commit": {
     "address": "fluree:memory://...",
     "hash": "..."
@@ -218,7 +243,7 @@ Expected output (SPARQL Results JSON format):
 }
 ```
 
-### Insert Data
+### Insert More Data
 
 The `/insert` endpoint adds new data to the ledger. If the subject already exists, the operation will merge the new properties with existing ones:
 

--- a/src/fluree/server/broadcast/subscriptions.clj
+++ b/src/fluree/server/broadcast/subscriptions.clj
@@ -100,9 +100,12 @@
 (defrecord Subscriptions [state]
   Broadcaster
   (-broadcast-commit [_ ledger-id event]
-    (let [action  (events/event-type event)
-          message (select-keys event [:tx-id :commit :t])]
-      (send-message-to-all state ledger-id action message)))
+    (let [{:keys [address hash]} (:commit event)
+          message {:tx-id (:tx-id event)
+                   :address address
+                   :hash hash
+                   :t (:t event)}]
+      (send-message-to-all state ledger-id "new-commit" message)))
   (-broadcast-drop [_ ledger-id event]
     (let [action (events/event-type event)]
       (send-message-to-all state ledger-id action event)))

--- a/src/fluree/server/consensus/events.clj
+++ b/src/fluree/server/consensus/events.clj
@@ -30,7 +30,10 @@
 
 (defn with-txn
   [evt txn]
-  (cond (txn-address? txn)
+  (cond (nil? txn)
+        evt
+
+        (txn-address? txn)
         (assoc evt :txn-address txn)
 
         (jld-txn? txn)

--- a/src/fluree/server/consensus/shared/create.clj
+++ b/src/fluree/server/consensus/shared/create.clj
@@ -1,0 +1,42 @@
+(ns fluree.server.consensus.shared.create
+  "Shared functions for ledger creation across consensus mechanisms."
+  (:require [fluree.db.api :as fluree]
+            [fluree.db.util.log :as log]))
+
+(defn hash-from-id
+  "Extracts the hash portion from a commit ID.
+  Commit IDs have format: 'fluree:commit:sha256:b<base32-hash>'"
+  [commit-id]
+  (when (string? commit-id)
+    (let [prefix "fluree:commit:sha256:b"]
+      (when (.startsWith ^String commit-id prefix)
+        (subs commit-id (count prefix))))))
+
+(defn genesis-result
+  "Creates a commit result map for a genesis commit."
+  [ledger]
+  (let [db     (fluree/db ledger)
+        commit (:commit db)]
+    {:db      db
+     :address (:address commit)
+     :hash    (or (:hash commit)
+                  (hash-from-id (:id commit)))}))
+
+(defn file-result
+  "Creates a commit result map with file metadata structure.
+  Used by Raft consensus. Genesis commits have data files but with empty assertions."
+  [ledger]
+  (let [db         (fluree/db ledger)
+        commit     (:commit db)
+        ;; Genesis commits have a data file referenced in the commit
+        data-addr  (-> commit :data :address)]
+    (when-not data-addr
+      (log/warn "Genesis commit missing expected data file address"))
+    {:db          db
+     :data-file   (when data-addr {:address data-addr})  ; Genesis commits do have data files
+     :commit-file {:address (:address commit)
+                   :json    nil}  ; Will be populated by consensus
+     ;; These fields are expected by the event system
+     :address     (:address commit)
+     :hash        (or (:hash commit)
+                      (hash-from-id (:id commit)))}))

--- a/src/fluree/server/consensus/shared/create.clj
+++ b/src/fluree/server/consensus/shared/create.clj
@@ -1,16 +1,24 @@
 (ns fluree.server.consensus.shared.create
   "Shared functions for ledger creation across consensus mechanisms."
-  (:require [fluree.db.api :as fluree]
+  (:require [clojure.string :as str]
+            [fluree.db.api :as fluree]
             [fluree.db.util.log :as log]))
+
+(def commit-id-prefix "fluree:commit:sha256:b")
+
+(defn commit-id?
+  "Checks if a string is a valid commit ID.
+  Commit IDs have format: 'fluree:commit:sha256:b<base32-hash>'"
+  [commit-id]
+  (and (string? commit-id)
+       (str/starts-with? commit-id commit-id-prefix)))
 
 (defn hash-from-id
   "Extracts the hash portion from a commit ID.
   Commit IDs have format: 'fluree:commit:sha256:b<base32-hash>'"
   [commit-id]
-  (when (string? commit-id)
-    (let [prefix "fluree:commit:sha256:b"]
-      (when (.startsWith ^String commit-id prefix)
-        (subs commit-id (count prefix))))))
+  (when (commit-id? commit-id)
+    (subs commit-id (count commit-id-prefix))))
 
 (defn genesis-result
   "Creates a commit result map for a genesis commit."

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -52,7 +52,7 @@
   (m/schema [:map-of :keyword :any]))
 
 (def TValue
-  (m/schema pos-int?))
+  (m/schema nat-int?))
 
 (def DID
   (m/schema [:string {:min 1}]))

--- a/src/fluree/server/handlers/create.clj
+++ b/src/fluree/server/handlers/create.clj
@@ -23,20 +23,32 @@
     (watcher/monitor p ledger-id result-ch :tx-id tx-id)
     p))
 
+(defn- extract-ledger-id
+  "Extracts ledger ID from request body, options, or transaction."
+  [body opts txn]
+  (or (get body "ledger")
+      (:ledger opts)
+      (when txn (srv-tx/extract-ledger-id txn))))
+
+(defn- prepare-create-options
+  "Prepares options for ledger creation.
+  Removes :identity since empty ledgers have no policies to check."
+  [opts]
+  (dissoc opts :identity))
+
 (defhandler default
   [{:keys          [fluree/opts fluree/consensus fluree/watcher]
     {:keys [body]} :parameters}]
   (log/debug "create body:" body)
-  (let [txn          (fluree/format-txn body opts)
-        ledger-id    (or (:ledger opts)
-                         (srv-tx/extract-ledger-id txn))
-        opts*        (dissoc opts :identity) ; Remove identity option because the
-                                             ; request should have been validated
-                                             ; upstream, and there are no policies
-                                             ; in an empty ledger to allow any
-                                             ; actions
-        commit-event (deref! (create-ledger! consensus watcher ledger-id txn opts*))
-
-        body (srv-tx/commit-event->response-body commit-event)]
+  (let [has-txn-data? (contains? body "insert")
+        txn           (when has-txn-data?
+                        (fluree/format-txn body opts))
+        ledger-id     (extract-ledger-id body opts txn)
+        _             (when-not ledger-id
+                        (throw (ex-info "Ledger ID must be provided"
+                                        {:status 400 :error :db/invalid-ledger-id})))
+        opts*         (prepare-create-options opts)
+        commit-event  (deref! (create-ledger! consensus watcher ledger-id txn opts*))
+        body          (srv-tx/commit-event->response-body commit-event)]
     (shared/with-tracking-headers {:status 201, :body body}
       commit-event)))

--- a/test/fluree/server/integration/basic_transaction_test.clj
+++ b/test/fluree/server/integration/basic_transaction_test.clj
@@ -18,9 +18,28 @@
                                      "ex:name" "create-endpoint-test"}]})
           res         (api-post :create {:body req :headers json-headers})]
       (is (= 201 (:status res)))
+      ;; Should return t: 1 for genesis commit + transaction commit
       (is (= {"ledger" ledger-name
               "t"      1}
              (-> res :body (json/parse false) (select-keys ["ledger" "t"])))))))
+
+(deftest ^:integration ^:json create-endpoint-without-data-json-test
+  (testing "can create a new ledger without initial data w/ JSON"
+    (let [ledger-name (str "create-endpoint-no-data-" (random-uuid))
+          req         (json/stringify
+                       {"ledger" ledger-name})
+          res         (api-post :create {:body req :headers json-headers})
+          body        (json/parse (:body res) false)]
+      (is (= 201 (:status res)))
+      ;; Should return t: 0 for genesis commit only (no transaction data)
+      (is (= {"ledger" ledger-name
+              "t"      0}
+             (select-keys body ["ledger" "t"])))
+      ;; Should have same response structure as creation with data
+      (is (contains? body "tx-id"))
+      (is (contains? body "commit"))
+      (is (contains? (get body "commit") "address"))
+      (is (contains? (get body "commit") "hash")))))
 
 #_(deftest ^:integration ^:edn create-endpoint-edn-test
     (testing "can create a new ledger w/ EDN"

--- a/test/fluree/server/integration/readme_examples_test.clj
+++ b/test/fluree/server/integration/readme_examples_test.clj
@@ -8,22 +8,31 @@
 (deftest readme-examples-test
   (testing "README API Examples"
 
-    ;; Example 1: Create a New Ledger with an Initial Commit
-    (testing "Create ledger with initial data"
+    ;; Example 1: Create a New Ledger (empty)
+    (testing "Create ledger without initial data"
       (let [create-response (test-system/api-post
                              :create
                              {:body (json/stringify
-                                     {"ledger" "example/ledger"
-                                      "@context" {"schema" "http://schema.org/"
-                                                  "ex" "http://example.org/"}
-                                      "insert" [{"@id" "ex:alice"
-                                                 "@type" "schema:Person"
-                                                 "schema:name" "Alice Johnson"
-                                                 "schema:email" "alice@example.com"}]})
+                                     {"ledger" "example/ledger"})
                               :headers test-system/json-headers})]
         (is (= 201 (:status create-response)))))
 
-    ;; Example 2: Insert Additional Data
+    ;; Example 2: Insert Alice
+    (testing "Insert Alice as first data"
+      (let [insert-response (test-system/api-post
+                             :insert
+                             {:body (json/stringify
+                                     {"@context" {"schema" "http://schema.org/"
+                                                  "ex" "http://example.org/"}
+                                      "@graph" [{"@id" "ex:alice"
+                                                 "@type" "schema:Person"
+                                                 "schema:name" "Alice Johnson"
+                                                 "schema:email" "alice@example.com"}]})
+                              :headers (assoc test-system/json-headers
+                                              "fluree-ledger" "example/ledger")})]
+        (is (= 200 (:status insert-response)))))
+
+    ;; Example 3: Insert Additional Data
     (testing "Add Bob who knows Alice"
       (let [insert-response (test-system/api-post
                              :insert
@@ -39,7 +48,7 @@
                                               "fluree-ledger" "example/ledger")})]
         (is (= 200 (:status insert-response))))))
 
-    ;; Example 3: Query Data
+    ;; Example 4: Query Data
   (testing "Query all Person entities"
     (let [query-response (test-system/api-post
                           :query
@@ -70,7 +79,7 @@
                 "schema:knows" {"@id" "ex:alice"}}
                bob)))))
 
-    ;; Example 4: SPARQL Query
+    ;; Example 5: SPARQL Query
   (testing "SPARQL query for all persons"
     (let [sparql-query "PREFIX schema: <http://schema.org/>
                          PREFIX ex: <http://example.org/>
@@ -98,7 +107,7 @@
           (let [names (set (map #(get-in % ["name" "value"]) bindings))]
             (is (= #{"Alice Johnson" "Bob Smith"} names)))))))
 
-    ;; Example 5: Insert Data (Charlie)
+    ;; Example 6: Insert Data (Charlie)
   (testing "Insert Charlie using /insert endpoint"
     (let [insert-response (test-system/api-post
                            :insert
@@ -113,7 +122,7 @@
                                             "fluree-ledger" "example/ledger")})]
       (is (= 200 (:status insert-response)))))
 
-    ;; Example 6: Update Data
+    ;; Example 7: Update Data
   (testing "Update Alice's email"
     (let [update-response (test-system/api-post
                            :update
@@ -130,7 +139,7 @@
                                             "fluree-ledger" "example/ledger")})]
       (is (= 200 (:status update-response)))))
 
-    ;; Example 7: Upsert Data
+    ;; Example 8: Upsert Data
   (testing "Upsert Alice's age and add Diana"
     (let [upsert-response (test-system/api-post
                            :upsert
@@ -176,7 +185,7 @@
                 "schema:email" "diana@example.com"}
                diana)))))
 
-    ;; Example 6: Insert with Turtle Format
+    ;; Example 9: Insert with Turtle Format
   (testing "Insert Emily using Turtle format"
     (let [turtle-data "@prefix schema: <http://schema.org/> .
 @prefix ex: <http://example.org/> .
@@ -193,7 +202,7 @@ ex:emily a schema:Person ;
                                             "fluree-ledger" "example/ledger")})]
       (is (= 200 (:status insert-response)))))
 
-    ;; Example 7: Upsert with Turtle Format
+    ;; Example 10: Upsert with Turtle Format
   (testing "Upsert Emily's job title and add Frank using Turtle format"
     (let [turtle-data "@prefix schema: <http://schema.org/> .
 @prefix ex: <http://example.org/> .
@@ -240,7 +249,7 @@ ex:frank a schema:Person ;
                 "schema:email" "frank@example.com"}
                frank))))
 
-    ;; Example 8: Time Travel Query at t=2
+    ;; Example 11: Time Travel Query at t=2
     (testing "Query at transaction 2 (before email update)"
       (let [time-query-response (test-system/api-post
                                  :query
@@ -264,7 +273,7 @@ ex:frank a schema:Person ;
                   "schema:email" "alice@example.com"}
                  alice)))))
 
-    ;; Example 7: Current state query (after update)
+    ;; Example 12: Current state query (after update)
     (testing "Query current state shows updated email"
       (let [current-query-response (test-system/api-post
                                     :query
@@ -288,7 +297,7 @@ ex:frank a schema:Person ;
                   "schema:age" 43}
                  alice))))) ;; Should have age from upsert
 
-    ;; Example 10: History Query for a Specific Subject
+    ;; Example 13: History Query for a Specific Subject
     (testing "Query history for Alice"
       (let [history-response (test-system/api-post
                               :history


### PR DESCRIPTION
## Summary
- Allow t=0 for genesis commits in API schema validation
- Extract hash from commit ID for consistent response format across all ledger creation scenarios
- Add shared functions for genesis commit handling between standalone and Raft consensus
- Fix broadcast action to "new-commit" for client compatibility with remote connections
- Update documentation to show simple ledger creation as primary example
- Add test coverage for creation without initial data
- Ensure README examples and tests are consistent with new transaction sequence

## Test plan
- [x] Add unit test for creating ledger without initial data
- [x] Update existing integration tests to handle new transaction numbering
- [x] Verify API schema accepts t=0 genesis commits
- [x] Confirm broadcast compatibility with remote connections
- [x] Update README examples and ensure consistency with test suite
- [x] Run cljfmt fix to ensure code formatting