### PR TITLE
update crypto api usages

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,7 +6,7 @@
 
         integrant/integrant {:mvn/version "0.10.0"}
         com.fluree/crypto   {:git/url "https://github.com/fluree/fluree.crypto.git"
-                             :git/sha "cd92370b7c49aac78720833f520787dcebe86b9e"}
+                             :git/sha "065c425d98c97cb648f01ad3c708f2c71c80e11d"}
 
         ;; network, consensus
         com.github.fluree/raft {:git/tag "v1.0.0-beta2"

--- a/deps.edn
+++ b/deps.edn
@@ -1,11 +1,12 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "9a92e713e4c78cc3169bf4b7be9ea531234e9dd0"}
+                                :git/sha "db9960c95a91d539596df54c134e6f99aed7294d"}
         com.fluree/json-ld     {:mvn/version "1.0.1"}
 
         integrant/integrant {:mvn/version "0.10.0"}
-        com.fluree/crypto   {:mvn/version "3.0.1"}
+        com.fluree/crypto   {:git/url "https://github.com/fluree/fluree.crypto.git"
+                             :git/sha "cd92370b7c49aac78720833f520787dcebe86b9e"}
 
         ;; network, consensus
         com.github.fluree/raft {:git/tag "v1.0.0-beta2"

--- a/test/fluree/server/integration/closed_mode_test.clj
+++ b/test/fluree/server/integration/closed_mode_test.clj
@@ -44,8 +44,7 @@
                                     "f:query" {"@type" "@json"
                                                "@value" {}}}]}}
             resp (api-post :create {:body    (crypto/create-jws (json/stringify create-req)
-                                                                (:private root-auth)
-                                                                {:include-pubkey true})
+                                                                (:private root-auth))
                                     :headers jwt-headers})]
         (testing "is accepted"
           (is (= 201 (:status resp))))))
@@ -54,8 +53,7 @@
                           "@context" default-context
                           "insert" [{"@id" "ex:coin" "ex:name" "nickel"}]}
             resp (api-post :transact {:body (crypto/create-jws (json/stringify transact-req)
-                                                               (:private root-auth)
-                                                               {:include-pubkey true})
+                                                               (:private root-auth))
                                       :headers jwt-headers})]
         (testing "is accepted"
           (is (= 200 (:status resp))))))
@@ -65,8 +63,7 @@
                        "where" [{"@id" "?s" "ex:name" "?name"}]
                        "select" "?s"}
             resp (api-post :query {:body (crypto/create-jws (json/stringify query-req)
-                                                            (:private root-auth)
-                                                            {:include-pubkey true})
+                                                            (:private root-auth))
                                    :headers jwt-headers})]
         (testing "is accepted"
           (is (= 200 (:status resp)))
@@ -78,8 +75,7 @@
                          "history" "ex:coin"
                          "t" {"from" 1 "to" "latest"}}
             resp (api-post :history {:body (crypto/create-jws (json/stringify history-req)
-                                                              (:private root-auth)
-                                                              {:include-pubkey true})
+                                                              (:private root-auth))
                                      :headers jwt-headers})]
         (testing "is accepted"
           (is (= 200 (:status resp)))
@@ -90,8 +86,7 @@
     (testing "to drop"
       (let [drop-req {"ledger" "closed-test"}
             resp     (api-post :drop {:body (crypto/create-jws (json/stringify drop-req)
-                                                               (:private root-auth)
-                                                               {:include-pubkey true})
+                                                               (:private root-auth))
                                       :headers jwt-headers})]
         (testing "is accepted"
           (is (= 200 (:status resp)))))))
@@ -111,8 +106,7 @@
                                     "f:query" {"@type" "@json"
                                                "@value" {}}}]}}
             resp (api-post :create {:body    (crypto/create-jws (json/stringify create-req)
-                                                                (:private non-root-auth)
-                                                                {:include-pubkey true})
+                                                                (:private non-root-auth))
                                     :headers jwt-headers})]
         (testing "is rejected"
           (is (= 403 (:status resp)))
@@ -120,16 +114,14 @@
 
         ;; create as root for further testing
         (api-post :create {:body (crypto/create-jws (json/stringify create-req)
-                                                    (:private root-auth)
-                                                    {:include-pubkey true})
+                                                    (:private root-auth))
                            :headers jwt-headers})))
     (testing "to transact"
       (let [create-req {"ledger" "closed-test2"
                         "@context" default-context
                         "insert" [{"@id" "ex:coin" "ex:name" "nickel"}]}
             resp (api-post :transact {:body (crypto/create-jws (json/stringify create-req)
-                                                               (:private non-root-auth)
-                                                               {:include-pubkey true})
+                                                               (:private non-root-auth))
                                       :headers jwt-headers})]
         (testing "is rejected"
           (is (= 403 (:status resp))))))
@@ -139,8 +131,7 @@
                         "where" [{"@id" "?s" "ex:name" "?name"}]
                         "select" ["?s" "?name"]}
             resp (api-post :query {:body (crypto/create-jws (json/stringify create-req)
-                                                            (:private non-root-auth)
-                                                            {:include-pubkey true})
+                                                            (:private non-root-auth))
                                    :headers jwt-headers})]
         (testing "is accepted"
           (is (= 200 (:status resp)))
@@ -151,8 +142,7 @@
                         "history" "ex:coin"
                         "t" {"from" 1}}
             resp (api-post :history {:body (crypto/create-jws (json/stringify create-req)
-                                                              (:private non-root-auth)
-                                                              {:include-pubkey true})
+                                                              (:private non-root-auth))
                                      :headers jwt-headers})]
         (testing "is accepted"
           (is (= 200 (:status resp)))
@@ -165,8 +155,7 @@
                         ;; claiming root-auth identity in opts
                         "opts" {"did" (:id root-auth)}}
             resp (api-post :query {:body (crypto/create-jws (json/stringify create-req)
-                                                            (:private non-root-auth)
-                                                            {:include-pubkey true})
+                                                            (:private non-root-auth))
                                    :headers jwt-headers})]
         (testing "is silently demoted"
           (is (= 200 (:status resp)))
@@ -174,8 +163,7 @@
     (testing "to drop"
       (let [drop-req {"ledger" "closed-test2"}
             resp     (api-post :drop {:body (crypto/create-jws (json/stringify drop-req)
-                                                               (:private non-root-auth)
-                                                               {:include-pubkey true})
+                                                               (:private non-root-auth))
                                       :headers jwt-headers})]
         (testing "is rejected"
           (is (= 403 (:status resp)))))))

--- a/test/fluree/server/integration/closed_mode_test.clj
+++ b/test/fluree/server/integration/closed_mode_test.clj
@@ -23,9 +23,9 @@
 
 (def root-auth auth)
 (def non-root-auth
-  {:id "did:fluree:Tf4KTeKpWcZAJadKfJ4JUv84dkBYy5KFHod"
-   :private "8d542edcd3a11b4ca5faabe7c9fa09045d6f489b9461518dbd86c6c9e3b21fec",
-   :public "03ad2f0920fd7e8b77b422f0922f53abd260336be2a3fccdc1bfadd8d858da149b"})
+  {:id "did:key:z6MkiKJFxJJd9QuqKgzBR2kiSybE9V2517sFd2kTS7kQe9mg",
+   :public "39649a89208b4fbcf818de6716b17a0b1a2f7b63ad7de55187130f39a4ef7157",
+   :private "8d542edcd3a11b4ca5faabe7c9fa09045d6f489b9461518dbd86c6c9e3b21fec"})
 
 (deftest closed-mode
   ;; all endpoints
@@ -44,7 +44,8 @@
                                     "f:query" {"@type" "@json"
                                                "@value" {}}}]}}
             resp (api-post :create {:body    (crypto/create-jws (json/stringify create-req)
-                                                                (:private root-auth))
+                                                                (:private root-auth)
+                                                                {:include-pubkey true})
                                     :headers jwt-headers})]
         (testing "is accepted"
           (is (= 201 (:status resp))))))
@@ -53,7 +54,8 @@
                           "@context" default-context
                           "insert" [{"@id" "ex:coin" "ex:name" "nickel"}]}
             resp (api-post :transact {:body (crypto/create-jws (json/stringify transact-req)
-                                                               (:private root-auth))
+                                                               (:private root-auth)
+                                                               {:include-pubkey true})
                                       :headers jwt-headers})]
         (testing "is accepted"
           (is (= 200 (:status resp))))))
@@ -63,11 +65,12 @@
                        "where" [{"@id" "?s" "ex:name" "?name"}]
                        "select" "?s"}
             resp (api-post :query {:body (crypto/create-jws (json/stringify query-req)
-                                                            (:private root-auth))
+                                                            (:private root-auth)
+                                                            {:include-pubkey true})
                                    :headers jwt-headers})]
         (testing "is accepted"
           (is (= 200 (:status resp)))
-          (is (= ["did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh" "ex:coin"]
+          (is (= ["did:key:z6MkmbNqfM3ANYZnzDp9YDfa62pHggKosBkCyVdgQtgEKkGQ" "ex:coin"]
                  (-> resp :body (json/parse false)))))))
     (testing "to query history"
       (let [history-req {"from" "closed-test"
@@ -75,7 +78,8 @@
                          "history" "ex:coin"
                          "t" {"from" 1 "to" "latest"}}
             resp (api-post :history {:body (crypto/create-jws (json/stringify history-req)
-                                                              (:private root-auth))
+                                                              (:private root-auth)
+                                                              {:include-pubkey true})
                                      :headers jwt-headers})]
         (testing "is accepted"
           (is (= 200 (:status resp)))
@@ -86,7 +90,8 @@
     (testing "to drop"
       (let [drop-req {"ledger" "closed-test"}
             resp     (api-post :drop {:body (crypto/create-jws (json/stringify drop-req)
-                                                               (:private root-auth))
+                                                               (:private root-auth)
+                                                               {:include-pubkey true})
                                       :headers jwt-headers})]
         (testing "is accepted"
           (is (= 200 (:status resp)))))))
@@ -106,7 +111,8 @@
                                     "f:query" {"@type" "@json"
                                                "@value" {}}}]}}
             resp (api-post :create {:body    (crypto/create-jws (json/stringify create-req)
-                                                                (:private non-root-auth))
+                                                                (:private non-root-auth)
+                                                                {:include-pubkey true})
                                     :headers jwt-headers})]
         (testing "is rejected"
           (is (= 403 (:status resp)))
@@ -114,14 +120,16 @@
 
         ;; create as root for further testing
         (api-post :create {:body (crypto/create-jws (json/stringify create-req)
-                                                    (:private root-auth))
+                                                    (:private root-auth)
+                                                    {:include-pubkey true})
                            :headers jwt-headers})))
     (testing "to transact"
       (let [create-req {"ledger" "closed-test2"
                         "@context" default-context
                         "insert" [{"@id" "ex:coin" "ex:name" "nickel"}]}
             resp (api-post :transact {:body (crypto/create-jws (json/stringify create-req)
-                                                               (:private non-root-auth))
+                                                               (:private non-root-auth)
+                                                               {:include-pubkey true})
                                       :headers jwt-headers})]
         (testing "is rejected"
           (is (= 403 (:status resp))))))
@@ -131,7 +139,8 @@
                         "where" [{"@id" "?s" "ex:name" "?name"}]
                         "select" ["?s" "?name"]}
             resp (api-post :query {:body (crypto/create-jws (json/stringify create-req)
-                                                            (:private non-root-auth))
+                                                            (:private non-root-auth)
+                                                            {:include-pubkey true})
                                    :headers jwt-headers})]
         (testing "is accepted"
           (is (= 200 (:status resp)))
@@ -142,7 +151,8 @@
                         "history" "ex:coin"
                         "t" {"from" 1}}
             resp (api-post :history {:body (crypto/create-jws (json/stringify create-req)
-                                                              (:private non-root-auth))
+                                                              (:private non-root-auth)
+                                                              {:include-pubkey true})
                                      :headers jwt-headers})]
         (testing "is accepted"
           (is (= 200 (:status resp)))
@@ -155,7 +165,8 @@
                         ;; claiming root-auth identity in opts
                         "opts" {"did" (:id root-auth)}}
             resp (api-post :query {:body (crypto/create-jws (json/stringify create-req)
-                                                            (:private non-root-auth))
+                                                            (:private non-root-auth)
+                                                            {:include-pubkey true})
                                    :headers jwt-headers})]
         (testing "is silently demoted"
           (is (= 200 (:status resp)))
@@ -163,7 +174,8 @@
     (testing "to drop"
       (let [drop-req {"ledger" "closed-test2"}
             resp     (api-post :drop {:body (crypto/create-jws (json/stringify drop-req)
-                                                               (:private non-root-auth))
+                                                               (:private non-root-auth)
+                                                               {:include-pubkey true})
                                       :headers jwt-headers})]
         (testing "is rejected"
           (is (= 403 (:status resp)))))))

--- a/test/fluree/server/integration/policy_test.clj
+++ b/test/fluree/server/integration/policy_test.clj
@@ -190,8 +190,7 @@
                                        "schema:ssn" "444-44-4444"}}
                   txn-res (api-post :transact {:body    (crypto/create-jws
                                                          (json/stringify txn-req)
-                                                         (:private auth)
-                                                         {:include-pubkey true})
+                                                         (:private auth))
                                                :headers {"Content-Type" "application/jwt"}})]
               (is (= 200
                      (:status txn-res))
@@ -206,8 +205,7 @@
                                         "schema:ssn" "333-33-3333"}]}
                   txn-res (api-post :transact {:body    (crypto/create-jws
                                                          (json/stringify txn-req)
-                                                         (:private auth)
-                                                         {:include-pubkey true})
+                                                         (:private auth))
                                                :headers {"Content-Type" "application/jwt"}})]
 
               (is (not= 200 (:status txn-res))
@@ -225,8 +223,7 @@
                              "t"        {"from" 1}}
                   query-res (api-post :history {:body    (crypto/create-jws
                                                           (json/stringify query-req)
-                                                          (:private auth)
-                                                          {:include-pubkey true})
+                                                          (:private auth))
                                                 :headers {"Content-Type" "application/jwt"}})]
 
               (is (= 200 (:status query-res)))

--- a/test/fluree/server/integration/policy_test.clj
+++ b/test/fluree/server/integration/policy_test.clj
@@ -190,9 +190,9 @@
                                        "schema:ssn" "444-44-4444"}}
                   txn-res (api-post :transact {:body    (crypto/create-jws
                                                          (json/stringify txn-req)
-                                                         (:private auth))
+                                                         (:private auth)
+                                                         {:include-pubkey true})
                                                :headers {"Content-Type" "application/jwt"}})]
-
               (is (= 200
                      (:status txn-res))
                   "txn signed by authorized user succeeds")))
@@ -206,7 +206,8 @@
                                         "schema:ssn" "333-33-3333"}]}
                   txn-res (api-post :transact {:body    (crypto/create-jws
                                                          (json/stringify txn-req)
-                                                         (:private auth))
+                                                         (:private auth)
+                                                         {:include-pubkey true})
                                                :headers {"Content-Type" "application/jwt"}})]
 
               (is (not= 200 (:status txn-res))
@@ -224,7 +225,8 @@
                              "t"        {"from" 1}}
                   query-res (api-post :history {:body    (crypto/create-jws
                                                           (json/stringify query-req)
-                                                          (:private auth))
+                                                          (:private auth)
+                                                          {:include-pubkey true})
                                                 :headers {"Content-Type" "application/jwt"}})]
 
               (is (= 200 (:status query-res)))

--- a/test/fluree/server/integration/test_system.clj
+++ b/test/fluree/server/integration/test_system.clj
@@ -164,8 +164,8 @@
        (throw (ex-info "Error creating random ledger" res))))))
 
 (def auth
-  {:id      "did:fluree:TfHgFTQQiJMHaK1r1qxVPZ3Ridj9pCozqnh"
-   :public  "03b160698617e3b4cd621afd96c0591e33824cb9753ab2f1dace567884b4e242b0"
+  {:id      "did:key:z6MkmbNqfM3ANYZnzDp9YDfa62pHggKosBkCyVdgQtgEKkGQ",
+   :public  "6a16232782dd2cc2896ccdfaf67ef91a54e4bbf98e4a73b6739465ccf1fe23c9",
    :private "509553eece84d5a410f1012e8e19e84e938f226aa3ad144e2d12f36df0f51c1e"})
 
 (defn run-closed-test-server


### PR DESCRIPTION
The default keypair generation now produces did:key strings as the :id key. I converted the existing ones by taking the private key and calling `fluree.db.did/private->did-map` with it.

I also updated calls `crypto/create-jws`, which with the new signing algorithm cannot derive the pubkey from the payload+sig, so needs to have the pubkey in the JWS header.