### PR TITLE
update example config to match docs

### DIFF
--- a/resources/file-config.jsonld
+++ b/resources/file-config.jsonld
@@ -52,7 +52,7 @@
     {
       "@id": "http",
       "@type": "API",
-      "httpPort": 58090,
+      "httpPort": 8090,
       "maxTxnWaitMs": 120000,
       "corsOrigins": ["*"]
     }


### PR DESCRIPTION
The docs advertise 8090, not 58090, as the port to send requests to.