### PR TITLE
Handler for returning storage content hashes

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "f39e1b8d0e91f629bd0caf8cd94bd2c30fd5dde0"}
+                                :git/sha "198d932cb97129f8464d59c0343029b9d25849b1"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "74083536c84d77f8cdd4b686b5661714010baad3"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "68f3b1a3feffa5e29d3ad109fb2956c5e6f88f59"}
+                                :git/sha "2709e2bf5a1f5e43cc90eeb001f5ce15ff7a8e68"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "74083536c84d77f8cdd4b686b5661714010baad3"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "7afeb027a02f5e9e1efe0122fd3f227b7b96abd9"}
+                                :git/sha "4ff9b68869400d2a2d13fcb0f25d22e139a7a265"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "74083536c84d77f8cdd4b686b5661714010baad3"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "60aeefb6f3a5297589517f656490631627a60272"}
+                                :git/sha "96ed6635cbb8c6b65f76d7037dbab5827df19f53"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "74083536c84d77f8cdd4b686b5661714010baad3"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "f3463ba3bf60707311411195beb5735eabae06f5"}
+                                :git/sha "0e4de6d1ca09e85da0c68a15e9581e2d1667d3bc"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "74083536c84d77f8cdd4b686b5661714010baad3"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "dd716bf396f9ef56af61acc3c42638bdb998c78c"}
+                                :git/sha "f3463ba3bf60707311411195beb5735eabae06f5"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "74083536c84d77f8cdd4b686b5661714010baad3"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "5b1072f2d8626889c77b1764f6ca02bdd8c95393"}
+                                :git/sha "fcc9724ac9a2d2628505bc5a617ede4269bb5550"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "74083536c84d77f8cdd4b686b5661714010baad3"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "198d932cb97129f8464d59c0343029b9d25849b1"}
+                                :git/sha "184b5dccd344a0bb8079ba5803c6ae1af3ce09be"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "74083536c84d77f8cdd4b686b5661714010baad3"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "fcc9724ac9a2d2628505bc5a617ede4269bb5550"}
+                                :git/sha "9a5dc7390ee6c25cfd670d2eb9bc51d470fc8233"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "74083536c84d77f8cdd4b686b5661714010baad3"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "9a5dc7390ee6c25cfd670d2eb9bc51d470fc8233"}
+                                :git/sha "60aeefb6f3a5297589517f656490631627a60272"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "74083536c84d77f8cdd4b686b5661714010baad3"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "d5b45bfe21617aa8c84d90a964ef9c5a21242398"}
+                                :git/sha "dd716bf396f9ef56af61acc3c42638bdb998c78c"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "74083536c84d77f8cdd4b686b5661714010baad3"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "4ff9b68869400d2a2d13fcb0f25d22e139a7a265"}
+                                :git/sha "d5b45bfe21617aa8c84d90a964ef9c5a21242398"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "74083536c84d77f8cdd4b686b5661714010baad3"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "8808f34e58252c09266a9dab5324189e8b05833b"}
+                                :git/sha "5b1072f2d8626889c77b1764f6ca02bdd8c95393"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "74083536c84d77f8cdd4b686b5661714010baad3"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "a38aff6fbdf9f016c16bf3a1d1445f6cb8685914"}
+                                :git/sha "6318743c3e7654cd13226cd56849caaf7d967365"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "74083536c84d77f8cdd4b686b5661714010baad3"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "33ea0a3e734862e51670200af76ab347dc875eef"}
+                                :git/sha "a38aff6fbdf9f016c16bf3a1d1445f6cb8685914"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "74083536c84d77f8cdd4b686b5661714010baad3"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "6318743c3e7654cd13226cd56849caaf7d967365"}
+                                :git/sha "68f3b1a3feffa5e29d3ad109fb2956c5e6f88f59"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "74083536c84d77f8cdd4b686b5661714010baad3"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "0e4de6d1ca09e85da0c68a15e9581e2d1667d3bc"}
+                                :git/sha "f39e1b8d0e91f629bd0caf8cd94bd2c30fd5dde0"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "74083536c84d77f8cdd4b686b5661714010baad3"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {org.clojure/clojure    {:mvn/version "1.11.3"}
         org.clojure/core.async {:mvn/version "1.6.681"}
         com.fluree/db          {:git/url "https://github.com/fluree/db.git"
-                                :git/sha "2709e2bf5a1f5e43cc90eeb001f5ce15ff7a8e68"}
+                                :git/sha "7afeb027a02f5e9e1efe0122fd3f227b7b96abd9"}
         com.fluree/json-ld     {:git/url "https://github.com/fluree/json-ld.git"
                                 :git/sha "74083536c84d77f8cdd4b686b5661714010baad3"}
 

--- a/src/fluree/server/consensus/raft/handlers/create_ledger.clj
+++ b/src/fluree/server/consensus/raft/handlers/create_ledger.clj
@@ -43,7 +43,7 @@
     (if txn
       ;; If transaction provided, update db and commit it
       (let [index-files-ch (new-index-file/monitor-chan config)
-            updated-db     (deref! (fluree/update conn ledger-id txn opts))
+            updated-db     (deref! (fluree/update db txn opts))
             resp           (deref! (fluree/commit! conn updated-db {:file-data?     true
                                                                     :index-files-ch index-files-ch}))]
         (log/debug "New ledger" ledger-id "created with tx-id: " tx-id)

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -569,7 +569,7 @@
             :parameters {:body AddressRequestBody}
             :handler    #'remote/read-resource-address}}]
    ["/hash"
-    {:post {:summary    "Read resource from address"
+    {:post {:summary    "Parse content hash from address"
             :parameters {:body HashRequestBody}
             :handler    #'remote/parse-address-hash}}]
    ["/addresses"

--- a/src/fluree/server/handler.clj
+++ b/src/fluree/server/handler.clj
@@ -137,6 +137,12 @@
              [:map
               [:resource Address]]]))
 
+(def HashRequestBody
+  (m/schema [:and
+             [:map-of :keyword :any]
+             [:map
+              [:address Address]]]))
+
 (def AliasRequestBody
   (m/schema [:and
              [:map-of :keyword :any]
@@ -562,6 +568,10 @@
     {:post {:summary    "Read resource from address"
             :parameters {:body AddressRequestBody}
             :handler    #'remote/read-resource-address}}]
+   ["/hash"
+    {:post {:summary    "Read resource from address"
+            :parameters {:body HashRequestBody}
+            :handler    #'remote/parse-address-hash}}]
    ["/addresses"
     {:post {:summary    "Retrieve ledger address from alias"
             :parameters {:body AliasRequestBody}

--- a/src/fluree/server/handlers/remote_resource.clj
+++ b/src/fluree/server/handlers/remote_resource.clj
@@ -2,6 +2,7 @@
   (:require [fluree.db.api :as-alias fluree]
             [fluree.db.connection :as connection]
             [fluree.db.util.async :refer [<??]]
+            [fluree.db.util.json :as json]
             [fluree.db.util.log :as log]
             [fluree.server.handlers.shared :refer [defhandler]]))
 
@@ -23,11 +24,11 @@
 
 (defhandler parse-address-hash
   [{:keys [fluree/conn]
-    {{resource-address :resource :as body} :body} :parameters}]
+    {{resource-address :address :as body} :body} :parameters}]
   (log/debug "Remote resource parse address hash request:" body)
   (let [result (<?? (connection/parse-address-hash conn resource-address))]
     {:status 200
-     :body   result}))
+     :body   (json/stringify result)}))
 
 (defhandler published-ledger-addresses
   [{:keys [fluree/conn]

--- a/src/fluree/server/handlers/remote_resource.clj
+++ b/src/fluree/server/handlers/remote_resource.clj
@@ -21,6 +21,14 @@
     {:status 200
      :body   result}))
 
+(defhandler parse-address-hash
+  [{:keys [fluree/conn]
+    {{resource-address :resource :as body} :body} :parameters}]
+  (log/debug "Remote resource parse address hash request:" body)
+  (let [result (<?? (connection/parse-address-hash conn resource-address))]
+    {:status 200
+     :body   result}))
+
 (defhandler published-ledger-addresses
   [{:keys [fluree/conn]
     {{:keys [ledger] :as body} :body} :parameters}]

--- a/test/fluree/server/integration/history_query_test.clj
+++ b/test/fluree/server/integration/history_query_test.clj
@@ -1,6 +1,7 @@
 (ns fluree.server.integration.history-query-test
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [fluree.db.util.json :as json]
+            [fluree.db.util.ledger :as ledger-util]
             [fluree.server.integration.test-system
              :as test-system
              :refer [api-post json-headers run-test-server]]))
@@ -52,8 +53,7 @@
       (let [history-expectations
             {["id"]                  #(re-matches commit-id-regex %)
              ["f:address"]           #(re-matches mem-addr-regex %)
-             ["f:alias"]             #(= % ledger-name)
-             ["f:branch"]            #(= % "main")
+             ["f:alias"]             #(= % (ledger-util/normalize-ledger-alias ledger-name))
              ["f:previous"]          #(or (nil? %)
                                           (re-matches commit-id-regex (get % "id")))
              ["f:time"]              pos-int?
@@ -66,9 +66,8 @@
              ["f:data" "f:t"]        pos-int?}]
         (is (every? #(every? (fn [[kp valid?]]
                                (let [actual (get-in % kp)]
-                                 (or
-                                  (valid? actual)
-                                  (println "invalid:" (pr-str actual)))))
+                                 (or (valid? actual)
+                                     (println "invalid:" (pr-str actual)))))
                              history-expectations)
                     (map #(get % "f:commit") query-results)))))))
 

--- a/test/fluree/server/integration/readme_examples_test.clj
+++ b/test/fluree/server/integration/readme_examples_test.clj
@@ -83,7 +83,7 @@
   (testing "SPARQL query for all persons"
     (let [sparql-query "PREFIX schema: <http://schema.org/>
                          PREFIX ex: <http://example.org/>
-                         
+
                          SELECT ?person ?name ?email
                          FROM <example/ledger>
                          WHERE {
@@ -319,6 +319,5 @@ ex:frank a schema:Person ;
           (is (every? #(and (contains? % "f:commit")
                             (contains? % "f:assert")
                             (contains? % "f:retract")
-                            (= "example/ledger" (get-in % ["f:commit" "f:alias"]))
-                            (= "main" (get-in % ["f:commit" "f:branch"])))
+                            (= "example/ledger:main" (get-in % ["f:commit" "f:alias"])))
                       history)))))))


### PR DESCRIPTION
This patch incorporates the changes in https://github.com/fluree/db/pull/1111 and adds a handler to return the content hash corresponding to an address for servers connected to others as remote systems.