### PR TITLE
Enhance CORS configuration for browser compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,6 +833,10 @@ settings include:
   (default: 120000)
 - `closedMode` - Enable closed mode (requires authentication)
 - `rootIdentities` - Array of root identity DIDs for authentication
+- `corsOrigins` - Array of allowed CORS origins (default: `["*"]` accepts all).
+  Can be exact URLs (e.g., `"https://app.example.com"`), regex patterns
+  (e.g., `"^https://.*\\.example\\.com$"`), or `"*"` wildcard. For production
+  deployments, restrict to specific origins for security
 
 #### Example Configuration
 Here's a minimal standalone server configuration:
@@ -865,8 +869,46 @@ Here's a minimal standalone server configuration:
     {
       "@id": "http",
       "@type": "API",
-      "httpPort": 8090
+      "httpPort": 8090,
+      "corsOrigins": ["*"]
     }
+  ]
+}
+```
+
+#### CORS Configuration Examples
+
+For development, accept all origins:
+```json
+{
+  "@id": "http",
+  "@type": "API",
+  "httpPort": 8090,
+  "corsOrigins": ["*"]
+}
+```
+
+For production, restrict to specific origins:
+```json
+{
+  "@id": "http",
+  "@type": "API",
+  "httpPort": 8090,
+  "corsOrigins": [
+    "https://app.example.com",
+    "https://dashboard.example.com"
+  ]
+}
+```
+
+Use regex patterns to match multiple subdomains:
+```json
+{
+  "@id": "http",
+  "@type": "API",
+  "httpPort": 8090,
+  "corsOrigins": [
+    "^https://.*\\.example\\.com$"
   ]
 }
 ```

--- a/test/fluree/server/handler_cors_test.clj
+++ b/test/fluree/server/handler_cors_test.clj
@@ -1,5 +1,6 @@
 (ns fluree.server.handler-cors-test
   (:require [clojure.test :refer [deftest is testing]]
+            [fluree.server.handler :as handler]
             [fluree.server.system :as system]))
 
 (deftest test-cors-origin-parsing
@@ -19,3 +20,29 @@
     (testing "Plain string origin"
       (let [origins (system/parse-cors-origins ["http://localhost:3000"])]
         (is (= ["http://localhost:3000"] origins))))))
+
+(deftest test-header-constants
+  (testing "Header constants are properly defined"
+    (testing "standard-request-headers includes common HTTP headers"
+      (is (some #{"content-type"} handler/standard-request-headers))
+      (is (some #{"accept"} handler/standard-request-headers))
+      (is (some #{"authorization"} handler/standard-request-headers)))
+
+    (testing "fluree-request-header-keys includes Fluree-specific headers"
+      (is (some #{"fluree-track-meta"} handler/fluree-request-header-keys))
+      (is (some #{"fluree-identity"} handler/fluree-request-header-keys))
+      (is (some #{"fluree-policy"} handler/fluree-request-header-keys))
+      (is (some #{"fluree-ledger"} handler/fluree-request-header-keys)))
+
+    (testing "fluree-response-header-keys is defined"
+      (is (seq handler/fluree-response-header-keys)))))
+
+(deftest test-wrap-cors-composition
+  (testing "wrap-cors function properly composes headers from constants"
+    (let [test-handler (fn [_] {:status 200 :body "OK"})
+          wrapped-handler (handler/wrap-cors nil test-handler)
+          ;; Call with a basic request to verify the middleware doesn't error
+          request {:request-method :get :uri "/test"}
+          response (wrapped-handler request)]
+      (is (= 200 (:status response)))
+      (is (= "OK" (:body response))))))


### PR DESCRIPTION
## Summary

Fixes CORS preflight failures that can occur when browsers send requests with custom headers or non-standard content types. This ensures Fluree Server works correctly with modern web applications making cross-origin requests.

## Problem

The current CORS implementation uses `:any` for allowed headers, which:
1. **Causes runtime errors** with the ring-cors library (not a valid value)
2. **Fails browser preflight checks** - browsers will block requests before they reach the server if the preflight response doesn't explicitly list allowed headers
3. **Missing OPTIONS handlers** - some routes return 404 on preflight OPTIONS requests

When a browser sends a request with custom headers (like `Fluree-Identity`) or non-simple content types (like `application/sparql-query`), it first sends a preflight OPTIONS request. If the server doesn't respond correctly, the browser blocks the actual request entirely - the server never even sees it.

## Changes

### 1. Centralized Header Management
- Created `standard-request-headers` constant for common HTTP headers
- Existing `fluree-request-header-keys` now serves as single source of truth
- Created `fluree-response-header-keys` for headers browsers can read
- CORS configuration now composes these constants automatically

### 2. Enhanced CORS Middleware
- Replaced `:any` with explicit header list from constants
- Added `Access-Control-Expose-Headers` so browsers can read Fluree response headers
- Added `Access-Control-Max-Age` (24 hours) to cache preflight responses and reduce network overhead
- Maintained backward-compatible defaults (wildcard origins)

### 3. OPTIONS Route Handlers
Added explicit OPTIONS handlers returning 204 status to all endpoints:
- `/fluree/create`, `/drop`, `/transact`, `/update`, `/insert`, `/upsert`
- `/fluree/query`, `/history`, `/subscribe`
- All `/fluree/remote/*` endpoints

### 4. Documentation
- Added `corsOrigins` to README Configuration Options
- Included examples for development (wildcard) and production (restricted origins)
- Documented regex pattern support

## Testing

- All existing tests pass
- Enhanced `handler_cors_test.clj` to verify header constants and middleware composition
- Manually verified preflight requests work correctly

## Security Considerations

- **No security changes** - maintains existing wildcard origin default
- Users can still restrict origins via config (e.g., `["https://app.example.com"]`)
- Production deployments should restrict origins; this is now documented

## Backward Compatibility

✅ Fully backward compatible:
- Same default behavior (accept all origins)
- No configuration changes required
- Existing `corsOrigins` config continues to work
- No API changes