### PR TITLE
Support LOG_LEVEL environment variable

### DIFF
--- a/dev/logback.xml
+++ b/dev/logback.xml
@@ -1,5 +1,6 @@
 <!-- Logback configuration. See http://logback.qos.ch/manual/index.html -->
 <configuration scan="true" scanPeriod="10 seconds">
+    <property scope="context" name="LOG_LEVEL" value="${LOG_LEVEL:-INFO}"/>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
@@ -7,15 +8,15 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="${LOG_LEVEL}">
         <appender-ref ref="STDOUT"/>
     </root>
 
     <logger name="user" level="ALL"/>
     <logger name="ch.qos.logback" level="WARN"/>
-    <logger name="fluree.server" level="INFO"/>
-    <logger name="fluree.db" level="INFO"/>
-    <logger name="fluree.db.consensus" level="INFO"/>
-    <logger name="fluree.db.messaging" level="INFO"/>
+    <logger name="fluree.server" level="${LOG_LEVEL}"/>
+    <logger name="fluree.db" level="${LOG_LEVEL}"/>
+    <logger name="fluree.db.consensus" level="${LOG_LEVEL}"/>
+    <logger name="fluree.db.messaging" level="${LOG_LEVEL}"/>
 
 </configuration>

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -1,4 +1,5 @@
 <configuration>
+    <property scope="context" name="LOG_LEVEL" value="${LOG_LEVEL:-INFO}"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
@@ -8,7 +9,7 @@
         </encoder>
     </appender>
 
-    <logger name="fluree" level="info" additivity="false">
+    <logger name="fluree" level="${LOG_LEVEL}" additivity="false">
         <appender-ref ref="CONSOLE"/>
     </logger>
 


### PR DESCRIPTION
## Summary

Adds `LOG_LEVEL` environment variable support to logback configuration files for runtime log level control.

## Changes

- Added `LOG_LEVEL` property with `INFO` default fallback
- Applied to all logger levels (root, fluree.server, fluree.db, fluree.db.consensus, fluree.db.messaging)
- Updated both `dev/logback.xml` and `resources/logback.xml`

## Usage

```bash
# Set log level via environment variable
export LOG_LEVEL=DEBUG
java -jar target/server-*.jar

# Or inline
LOG_LEVEL=TRACE java -jar target/server-*.jar
```

Valid levels: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`

## Backward Compatibility

✅ Defaults to `INFO` if `LOG_LEVEL` not set - no behavior change for existing deployments