### PR TITLE
make otel tracing self contained

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -56,8 +56,8 @@
    :jvm-opts    ["-Djdk.attach.allowAttachSelf"]}
 
   :otel
-  {:jvm-opts [ ;;; download jar from https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases
-              ;; "-javaagent:/path/to/opentelemetry-javaagent.jar"
+  {:jvm-opts [ ;; start a trace collector with e.g. docker run --rm -p 16686:16686 -p 4318:4318 jaegertracing/jaeger:2.11.0
+              "-javaagent:dev/resources/opentelemetry-javaagent.jar"
               "-Dotel.exporter.otlp.endpoint=http://localhost:4318"
               "-Dotel.exporter.otlp.protocol=http/protobuf"
               "-Dotel.logs.exporter=none"


### PR DESCRIPTION
Add java instrumentation agent to the repo so developers don't need to acquire the jar file themselves and update the deps.edn file with the local path.

This should make it easier to use instrumentation during development.